### PR TITLE
Fix filename for helm push to OCI in Github Action

### DIFF
--- a/.github/workflows/push_helm_chart.yml
+++ b/.github/workflows/push_helm_chart.yml
@@ -35,4 +35,4 @@ jobs:
         - name: Push Helm chart to GHCR
           run: |
             CHART_NAME=$(basename cloud-operator)
-            helm push ${CHART_NAME}${{ github.ref_name }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+            helm push cloud-operator/${CHART_NAME}-${{ github.ref_name }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/push_helm_chart.yml
+++ b/.github/workflows/push_helm_chart.yml
@@ -35,4 +35,4 @@ jobs:
         - name: Push Helm chart to GHCR
           run: |
             CHART_NAME=$(basename cloud-operator)
-            helm push cloud-operator/${CHART_NAME}-${{ github.ref_name }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+            helm push ${CHART_NAME}-${{ github.ref_name }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts


### PR DESCRIPTION
Helm push failing due to missing `-` and incorrect pathing.