### PR TITLE
Flush buffer before new log entry in Zap hook

### DIFF
--- a/.github/workflows/push_helm_chart.yml
+++ b/.github/workflows/push_helm_chart.yml
@@ -35,4 +35,4 @@ jobs:
         - name: Push Helm chart to GHCR
           run: |
             CHART_NAME=$(basename cloud-operator)
-            helm push ${CHART_NAME}${{ github.ref_name }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+            helm push ${CHART_NAME}-${{ github.ref_name }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/internal/controller/logger_manager.go
+++ b/internal/controller/logger_manager.go
@@ -219,6 +219,9 @@ func NewGRPClogger(grpcSyncer *BufferedGrpcWriteSyncer) *zap.SugaredLogger {
 			grpcSyncer.bufferLogEntry(&entry)
 			return nil
 		}
+
+		grpcSyncer.flush()
+
 		if err := grpcSyncer.sendLog(&entry); err != nil {
 			logger.Error("Error when sending logs to server", zap.Error(err))
 			grpcSyncer.bufferLogEntry(&entry)

--- a/internal/controller/logger_manager.go
+++ b/internal/controller/logger_manager.go
@@ -220,6 +220,7 @@ func NewGRPClogger(grpcSyncer *BufferedGrpcWriteSyncer) *zap.SugaredLogger {
 			return nil
 		}
 
+		// flush buffer so logs are sent in order to the server
 		grpcSyncer.flush()
 
 		if err := grpcSyncer.sendLog(&entry); err != nil {

--- a/internal/controller/logger_manager.go
+++ b/internal/controller/logger_manager.go
@@ -24,9 +24,6 @@ type ClientConnInterface interface {
 	Close() error
 }
 
-// mutex lock in close, run, and hook
-// remove from everything else
-
 // BufferedGrpcWriteSyncer is a custom zap writesync that writes to a grpc stream
 // In case stream is not connected it will buffer to memory
 type BufferedGrpcWriteSyncer struct {

--- a/internal/controller/logger_manager.go
+++ b/internal/controller/logger_manager.go
@@ -172,10 +172,10 @@ func (b *BufferedGrpcWriteSyncer) ListenToLogStream() {
 
 // bufferLog adds the log entry to in-memory buffer
 func (b *BufferedGrpcWriteSyncer) bufferLogEntry(entry *zapcore.Entry) {
-	b.buffer = append(b.buffer, entry)
 	if len(b.buffer) >= maxBufferSize {
-		b.flush()
+		b.lostLogEntriesCount += 1
 	}
+	b.buffer = append(b.buffer, entry)
 }
 
 // updateLogLevel sets the logger's log level based on the response from the server.


### PR DESCRIPTION
In the cloud-operator's Zap hook, when logging a new log entry, and the client is connected, the log entry is directly sent to the server, even if there are already log entries buffered that have not been flushed yet.
That results in logs being sent out of order to the server.