### PR TITLE
Incorrect version using go build ldl flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY api/ api/
 
 # Build
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X 'version.version=${VERSION}'" -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X 'github.com/illumio/cloud-operator/internal/version.version=${VERSION}'" -a -o manager cmd/main.go
 
 RUN go install github.com/google/gops@latest
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,9 +2,7 @@
 
 package version
 
-var (
-	version = "dev"
-)
+var version string
 
 // Version returns the version of the operator.
 func Version() string {


### PR DESCRIPTION
The cloud-operator version always evaluated to "dev" at runtime and I believe its due to setting version within this package. By setting it to dev instead of leaving it blank we are making that string immutable.