### PR TITLE
Addressing Falco Flows with Incomplete L4 Messages

### DIFF
--- a/internal/controller/flow_falco.go
+++ b/internal/controller/flow_falco.go
@@ -131,6 +131,7 @@ func createLayer3Message(source string, destination string, ipVersion string) (*
 	} else if ipVersion == "ipv6" {
 		return &pb.IP{Source: source, Destination: destination, IpVersion: pb.IPVersion_IP_VERSION_IPV6}, nil
 	}
+	// If this is IPVersion_IP_VERSION_IP_NOT_USED_UNSPECIFIED do we want to drop this packet?
 	return &pb.IP{Source: source, Destination: destination, IpVersion: pb.IPVersion_IP_VERSION_IP_NOT_USED_UNSPECIFIED}, nil
 }
 
@@ -172,5 +173,5 @@ func createLayer4Message(proto string, srcPort, dstPort uint32, ipVersion string
 		}
 	default:
 	}
-	return &pb.Layer4{}, nil
+	return &pb.Layer4{}, ErrFalcoIncompleteL4Flow
 }


### PR DESCRIPTION
We observed Falco returning incomplete L4 network logs. Instead of sending those incomplete flows to CloudSecure we want to just ignore them since we cannot make much sense of them.