### PR TITLE
Add jitter to the main "authenticate and open streams" loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-bin/
-cmd/cmd
-redeploy_easy.sh
-Makefile
+*local.yaml
+cloud-operator-*.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Variables
 APP_NAME := operator
-DOCKER_IMAGE := aaronnguyenillumio/$(APP_NAME)
+DOCKER_USERNAME := aaronnguyenillumio
+DOCKER_IMAGE := $(DOCKER_USERNAME)/$(APP_NAME)
 COMMIT := $(shell git rev-parse --short HEAD)
 DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := -ldflags "-X main.Version=latest -X main.Commit=$(COMMIT) -X main.Date=$(DATE)"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ This will delete all the resources associated with the `illumio` release from th
 - Kubernetes v1.30+ cluster.
 - helm version v3.15.4+
 
+## Making a private build
+
+The following `make` command will build and push a private build to `docker
+hub`.
+
+```
+docker login
+make docker-build docker-push DOCKER_USERNAME=arisweedler386
+```
+
+TODO: ENABLE LOCAL BUILD
+
 ## License
 
 Copyright 2024 Illumio, Inc. All Rights Reserved.

--- a/cloud-operator/values.yaml
+++ b/cloud-operator/values.yaml
@@ -5,8 +5,8 @@ replicaCount: 1
 priorityClassName: ""
 image:
   repository: "ghcr.io/illumio/cloud-operator"
-  tag: "v1.0.0"
-  pullPolicy: Always
+  tag: "0.0.1"
+  pullPolicy: IfNotPresent
 
 serviceAccount:
   create: true

--- a/cloud-operator/values.yaml
+++ b/cloud-operator/values.yaml
@@ -5,8 +5,8 @@ replicaCount: 1
 priorityClassName: ""
 image:
   repository: "ghcr.io/illumio/cloud-operator"
-  tag: "0.0.1"
-  pullPolicy: IfNotPresent
+  tag: "v1.0.0"
+  pullPolicy: Always
 
 serviceAccount:
   create: true

--- a/fakeserver/README.md
+++ b/fakeserver/README.md
@@ -1,0 +1,50 @@
+# `fakeserver`
+Illumio's `cloud-operator` streams data out to a server that you control.
+The `fakeserver` provides a convenient way to test out the cloud-operator
+without having a server to collect all those streams.
+
+# Running the `fakeserver`
+From the repo root:
+
+    go run ./fakeserver
+
+# Pointing `cloud-operator` to `fakeserver`
+
+`fakeserver` accepts a fake set of credentials. You can find the constants in
+the code:
+
+    # fakeserver respects these:
+    #    DefaultClientID     = "client_id_1"
+    #    DefaultClientSecret = "client_secret_1"
+    onboardingSecret:
+      clientId: "client_id_1"
+      clientSecret: "client_secret_1"
+
+Next, you must put the IP address of where `fakeserver` can be reached *from the
+context of the cluster*. Assuming that you're running `fakeserver` on the same
+host you're running the `k8s` cluster that `cloud-operator` is installed into,
+your first guess may be `localhost`. But that's not quite correct - as
+`cloud-operator` actually runs inside of a pod. Thus, you must use
+`host.docker.internal` to get to the host machine.
+
+And as for the port, well `fakeserver` serves on `50053`, by default
+
+    # This is where my k8s cluster can find my locally running services.
+    # '192.168.65.254' is some sort of magic IP addr for k8s...
+    env:
+      tlsSkipVerify: true
+      onboardingEndpoint: "https://host.docker.internal:50053/api/v1/k8s_cluster/onboard"
+      tokenEndpoint: "https://host.docker.internal:50053/api/v1/k8s_cluster/authenticate"
+
+## Putting it all together
+
+I've gone ahead and created a file `./cloud-operator.fakeserver.yaml` that
+contains all of these data. You can use it directly to install an instance of
+`cloud-operator` and run it against `fakeserver`.
+
+Here's the command I used to install the helm chart. The `--values` flag is the
+interesting part. By using these values, you will configure the `cloud-operator`
+to do the oauth onboarding handshake against `fakeserver` and then send all
+flows to it:
+
+    helm install illumio --namespace illumio-cloud --values ./fakeserver/cloud-operator.fakeserver.yaml ./cloud-operator/cloud-operator-1.0.0.tgz

--- a/fakeserver/cloud-operator.fakeserver.yaml
+++ b/fakeserver/cloud-operator.fakeserver.yaml
@@ -1,0 +1,18 @@
+# Copyright 2024 Illumio, Inc. All Rights Reserved.
+
+# fakeserver authenticates properly when your onboardingSecret matches these:
+#
+#    DefaultClientID     = "client_id_1"
+#    DefaultClientSecret = "client_secret_1"
+#
+onboardingSecret:
+  clientId: "client_id_1"
+  clientSecret: "client_secret_1"
+
+# * k8s pods clusters can find services on the host via 'host.docker.internal'
+# * fakeserver serves on port 50053
+# * fakeserver doesn't have a trustworthy certificate, so you wanna tlsSkipVerify
+env:
+  tlsSkipVerify: true
+  onboardingEndpoint: "https://host.docker.internal:50053/api/v1/k8s_cluster/onboard"
+  tokenEndpoint: "https://host.docker.internal:50053/api/v1/k8s_cluster/authenticate"

--- a/fakeserver/main.go
+++ b/fakeserver/main.go
@@ -42,5 +42,6 @@ func main() {
 	defer fs.stop()
 
 	// Wait indefinitely for server stop signal
+	logger.Info("Server started")
 	<-fs.stopChan
 }

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -472,13 +472,13 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 	// The happy path blocks inside the for loop.
 	// The unhappy path exits the for loop and hits the top-level select.
 	for {
-		failureReason := "We have not failed"
+		failureReason := ""
 		attempt++
-		logger.Infow("Trying to authenticate and open streams", "attempt", attempt)
+		logger.Debugw("Trying to authenticate and open streams", "attempt", attempt)
 
 		select {
 		case <-ctx.Done():
-			logger.Info("Context canceled while we were trying to authenticate and open streams")
+			logger.Warn("Context canceled while trying to authenticate and open streams")
 			return
 		case <-resetTimer.C:
 			authConContext, authConContextCancel := context.WithCancel(ctx)

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -474,7 +474,7 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 	for {
 		failureReason := ""
 		attempt++
-		logger.Debugw("Trying to authenticate and open streams", "attempt", attempt)
+		logger.Debug("Trying to authenticate and open streams", zap.Int("attempt", attempt))
 
 		select {
 		case <-ctx.Done():
@@ -545,10 +545,10 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 			authConContextCancel()
 		}
 
-		logger.With(
-			"failureReason", failureReason,
-			"attempt", attempt,
-		).Warn("One or more streams have been closed; closing and reopening the connection to CloudSecure")
+		logger.Warn("One or more streams have been closed; closing and reopening the connection to CloudSecure",
+			zap.String("failureReason", failureReason),
+			zap.Int("attempt", attempt),
+		)
 	}
 }
 


### PR DESCRIPTION
We want to avoid many cloud-operator instances all trying to authenticate at the same time.

To that effect, before we enter the "authenticate and open streams" loop, we need to add a jittery sleep