### PR TITLE
Fix Falco rules with new ipversion field + updating cloud-operator reboot logic to cope with long disconnect periods

### DIFF
--- a/cloud-operator/values.yaml
+++ b/cloud-operator/values.yaml
@@ -58,7 +58,7 @@ falco:
       - rule: kubernetes outbound connection
         desc: A pod in namespace attempted to connect to the outer world
         condition: outbound_corp and k8s.ns.name != ""
-        output: "illumio_network_traffic (time=%evt.time.iso8601 srcip=%fd.cip dstip=%fd.sip srcport=%fd.cport dstport=%fd.sport proto=%fd.l4proto procname=%proc.name)"
+        output: "illumio_network_traffic (time=%evt.time.iso8601 srcip=%fd.cip dstip=%fd.sip srcport=%fd.cport dstport=%fd.sport proto=%fd.l4proto procname=%proc.name ipversion=%fd.type)"
         priority: WARNING
 
 env:

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -395,13 +395,10 @@ func manageStream(logger *zap.SugaredLogger, connectAndStream func(*zap.SugaredL
 					resetTimer.Reset(resetPeriod)
 				case consecutiveFailures >= severeErrorThreshold:
 					sleepTimer.Reset(resetPeriod)
-					select {
-					case <-resetTimer.C:
-						consecutiveFailures = 0
-						backoff = initialBackoff
-						resetTimer.Reset(resetPeriod)
-
-					}
+					<-resetTimer.C // Wait for reset timer to reset the failure count
+					consecutiveFailures = 0
+					backoff = initialBackoff
+					resetTimer.Reset(resetPeriod)
 					continue
 				}
 

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -24,6 +24,7 @@ type streamClient struct {
 	conn                      *grpc.ClientConn
 	client                    pb.KubernetesInfoServiceClient
 	disableNetworkFlowsCilium bool
+	networkFlowWg             sync.WaitGroup
 	falcoEventChan            chan string
 	logStream                 pb.KubernetesInfoService_SendLogsClient
 	networkFlowsStream        pb.KubernetesInfoService_SendKubernetesNetworkFlowsClient
@@ -216,6 +217,7 @@ func (sm *streamManager) StreamCiliumNetworkFlows(ctx context.Context, ciliumNam
 	ciliumFlowCollector, err := newCiliumFlowCollector(ctx, sm.logger, ciliumNamespace)
 	if err != nil {
 		sm.logger.Infow("Failed to initialize Cilium Hubble Relay flow collector; disabling flow collector", "error", err)
+		sm.streamClient.disableNetworkFlowsCilium = true
 		return err
 	}
 	if ciliumFlowCollector != nil {
@@ -241,7 +243,6 @@ func (sm *streamManager) StreamFalcoNetworkFlows(ctx context.Context) error {
 			if len(match) < 2 {
 				return nil
 			}
-
 			convertedFalcoFlow, err := parsePodNetworkInfo(match[1])
 			if convertedFalcoFlow == nil {
 				// If the event can't be parsed, consider that it's not a flow event and just ignore it.
@@ -267,6 +268,7 @@ func (sm *streamManager) StreamFalcoNetworkFlows(ctx context.Context) error {
 func connectAndStreamCiliumNetworkFlows(logger *zap.SugaredLogger, sm *streamManager) error {
 	ciliumCtx, ciliumCancel := context.WithCancel(context.Background())
 	defer ciliumCancel()
+	defer sm.streamClient.networkFlowWg.Done()
 
 	sendCiliumNetworkFlowsStream, err := sm.streamClient.client.SendKubernetesNetworkFlows(ciliumCtx)
 	if err != nil {
@@ -391,7 +393,15 @@ func manageStream(logger *zap.SugaredLogger, connectAndStream func(*zap.SugaredL
 				case consecutiveFailures == 0:
 					resetTimer.Reset(resetPeriod)
 				case consecutiveFailures >= severeErrorThreshold:
-					return
+					sleepTimer.Reset(resetPeriod)
+					select {
+					case <-resetTimer.C:
+						consecutiveFailures = 0
+						backoff = initialBackoff
+						resetTimer.Reset(resetPeriod)
+
+					}
+					continue
 				}
 
 				consecutiveFailures++
@@ -466,10 +476,11 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 			}
 
 			streamClient := &streamClient{
-				conn:            authConn,
-				client:          client,
-				ciliumNamespace: envMap.CiliumNamespace,
-				falcoEventChan:  falcoEventChan,
+				conn:                      authConn,
+				client:                    client,
+				ciliumNamespace:           envMap.CiliumNamespace,
+				disableNetworkFlowsCilium: false,
+				falcoEventChan:            falcoEventChan,
 			}
 
 			sm := &streamManager{
@@ -477,24 +488,25 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 				logger:             logger,
 				bufferedGrpcSyncer: bufferedGrpcSyncer,
 			}
-
 			resourceDone := make(chan struct{})
 			logDone := make(chan struct{})
 			falcoDone := make(chan struct{})
 			var ciliumDone chan struct{}
 			sm.bufferedGrpcSyncer.done = logDone
-
 			go manageStream(logger, connectAndStreamResources, sm, resourceDone)
 			go manageStream(logger, connectAndStreamLogs, sm, logDone)
 			// Only start network flows stream if not disabled
 			if !sm.streamClient.disableNetworkFlowsCilium {
 				ciliumDone = make(chan struct{})
+				sm.streamClient.networkFlowWg.Add(1)
 				go manageStream(logger, connectAndStreamCiliumNetworkFlows, sm, ciliumDone)
+				sm.streamClient.networkFlowWg.Wait()
 				if !sm.streamClient.disableNetworkFlowsCilium {
 					falcoDone = nil
 				}
 			}
-			if !sm.streamClient.disableNetworkFlowsCilium {
+			if sm.streamClient.disableNetworkFlowsCilium {
+				sm.streamClient.networkFlowsStream = nil
 				ciliumDone = nil
 				go manageStream(logger, connectAndStreamFalcoNetworkFlows, sm, falcoDone)
 			}

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -506,7 +506,6 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 				}
 			}
 			if sm.streamClient.disableNetworkFlowsCilium {
-				sm.streamClient.networkFlowsStream = nil
 				ciliumDone = nil
 				go manageStream(logger, connectAndStreamFalcoNetworkFlows, sm, falcoDone)
 			}


### PR DESCRIPTION
- Add a field to Falco rule output in order to capture ip version.
- Fix a race condition when checking for hubble relay vs deciding which CNI to use.
- Fix the reboot timer logic for when a cluster is disconnected to disabled for a long period of time. After 10 severeErrors (or 10 failed connection attempts) the operator would return and stop attempting to connect. Modify that case to reset everything on the reset timer. Long term we may need to rewrite this reboot logic to distinguish between a cluster that has been disabled vs one that is actually having issues.