### PR TITLE
Revising context timeout logic when requesting a new token

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.

--- a/internal/controller/authenticator.go
+++ b/internal/controller/authenticator.go
@@ -153,14 +153,15 @@ func SetUpOAuthConnection(
 	clientSecret string,
 ) (*grpc.ClientConn, error) {
 	tlsConfig := GetTLSConfig(tlsSkipVerify)
-
+	contextWithTimeout, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
 	oauthConfig := clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		TokenURL:     tokenURL,
 		AuthStyle:    oauth2.AuthStyleInParams,
 	}
-	tokenSource := GetTokenSource(ctx, oauthConfig, tlsConfig)
+	tokenSource := GetTokenSource(contextWithTimeout, oauthConfig, tlsConfig)
 
 	token, err := tokenSource.Token()
 	if err != nil {

--- a/internal/controller/authenticator.go
+++ b/internal/controller/authenticator.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -542,16 +542,15 @@ func NewAuthenticatedConnection(ctx context.Context, logger *zap.SugaredLogger, 
 			return nil, nil, err
 		}
 		err = authn.WriteK8sSecret(ctx, responseData, envMap.ClusterCreds)
-		time.Sleep(1 * time.Second)
 		if err != nil {
 			logger.Errorw("Failed to write secret to Kubernetes", "error", err)
 		}
+		time.Sleep(1 * time.Second)
 		clientID, clientSecret, err = authn.ReadCredentialsK8sSecrets(ctx, envMap.ClusterCreds)
 		if err != nil {
 			logger.Errorw("Could not read K8s credentials", "error", err)
 		}
 	}
-
 	conn, err := SetUpOAuthConnection(ctx, logger, envMap.TokenEndpoint, envMap.TlsSkipVerify, clientID, clientSecret)
 	if err != nil {
 		logger.Errorw("Failed to set up an OAuth connection", "error", err)

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -464,7 +464,7 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 		case <-ctx.Done():
 			return
 		case <-resetTimer.C:
-			authConContext, authConContextCancel := context.WithTimeout(ctx, 10*time.Second)
+			authConContext, authConContextCancel := context.WithCancel(ctx)
 			authConn, client, err := NewAuthenticatedConnection(authConContext, logger, envMap)
 			if err != nil {
 				logger.Errorw("Failed to establish initial connection; will retry", "error", err)

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -453,6 +453,7 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 			err = falcoEvent.Serve(listener)
 			if err != nil && err != http.ErrServerClosed {
 				logger.Errorf("Falco server failed, restarting in 5 seconds... Error: %v", err)
+				// Giving some time before attempting to restart.....
 				time.Sleep(5 * time.Second)
 			}
 		}
@@ -545,6 +546,7 @@ func NewAuthenticatedConnection(ctx context.Context, logger *zap.SugaredLogger, 
 		if err != nil {
 			logger.Errorw("Failed to write secret to Kubernetes", "error", err)
 		}
+		// Sleeping just so k8s can finish writing the secret before we read from it.
 		time.Sleep(1 * time.Second)
 		clientID, clientSecret, err = authn.ReadCredentialsK8sSecrets(ctx, envMap.ClusterCreds)
 		if err != nil {


### PR DESCRIPTION
The context we had previously attached to our token refresh call had a timeout of 10 seconds. This means that our token would only be valid for that long. We are adjusting our context to only wrap the requests that retrieve a new token with a timeout to still failover if the request does not complete, but not to nullify the token itself.


Also adding consistency with how we are reading and writing k8s secrets.