### PR TITLE
Lower loglevel of spurious error logs on first client credential read

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 
-# Install debugging tools (including bash) and gops for troubleshooting
-RUN go install github.com/google/gops@latest
-
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -22,9 +19,12 @@ COPY internal/controller/ internal/controller/
 COPY internal/version/ internal/version/
 COPY internal/config internal/config
 COPY api/ api/
-
 # Build
+
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X 'github.com/illumio/cloud-operator/internal/version.version=${VERSION}'" -a -o manager cmd/main.go
+
+# Install debugging tools (including bash) and gops for troubleshooting
+RUN go install github.com/google/gops@latest
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 
+# Install debugging tools (including bash) and gops for troubleshooting
+RUN go install github.com/google/gops@latest
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -19,12 +22,9 @@ COPY internal/controller/ internal/controller/
 COPY internal/version/ internal/version/
 COPY internal/config internal/config
 COPY api/ api/
+
 # Build
-
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X 'github.com/illumio/cloud-operator/internal/version.version=${VERSION}'" -a -o manager cmd/main.go
-
-# Install debugging tools (including bash) and gops for troubleshooting
-RUN go install github.com/google/gops@latest
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/internal/controller/authenticator.go
+++ b/internal/controller/authenticator.go
@@ -66,12 +66,12 @@ func (authn *Authenticator) ReadCredentialsK8sSecrets(ctx context.Context, secre
 	// Assuming your secret data has a "client_id" and "client_secret" key.
 	clientID := string(secret.Data["client_id"])
 	if clientID == "" {
-		authn.Logger.Errorw("Cannot get client_id", "error", err)
+		authn.Logger.Errorw("Cannot get client_id")
 		return "", "", errors.New("failed to get client_id from secret")
 	}
 	clientSecret := string(secret.Data["client_secret"])
 	if clientSecret == "" {
-		authn.Logger.Errorw("Cannot get client_secret", "error", err)
+		authn.Logger.Errorw("Cannot get client_secret")
 		return "", "", errors.New("failed to get client_secret from secret")
 	}
 	return clientID, clientSecret, nil

--- a/internal/controller/authenticator_onboarding_credentials.go
+++ b/internal/controller/authenticator_onboarding_credentials.go
@@ -1,0 +1,47 @@
+package controller
+
+import "fmt"
+
+type credentialNotFoundInK8sSecretError struct {
+	RequiredFieldName onboardingCredentialRequiredField
+}
+
+type onboardingCredentialRequiredField string
+
+// Credentials contains attributes that are needed for onboarding.
+type Credentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+const (
+	ONBOARDING_CLIENT_ID     = onboardingCredentialRequiredField("client_id")
+	ONBOARDING_CLIENT_SECRET = onboardingCredentialRequiredField("client_secret")
+)
+
+var (
+	// In the onboarding flow, an administrator gives cloud-operator credentials
+	// via helm's value.yaml mechanism. For the sake of operability,
+	// cloud-operator then persists these credentials into a k8s secret, so
+	// subsequent installs on the same cluster do not require the administrator to
+	// repeat the credentials every time. There are multiple specific fields in
+	// this secret
+	//
+	// This error type indicates that at least one of the required fields is
+	// missing from the secret.
+	ErrCredentialNotFoundInK8sSecret error = &credentialNotFoundInK8sSecretError{}
+)
+
+func NewCredentialNotFoundInK8sSecretError(requiredField onboardingCredentialRequiredField) error {
+	return &credentialNotFoundInK8sSecretError{
+		RequiredFieldName: requiredField,
+	}
+}
+
+func (e *credentialNotFoundInK8sSecretError) Error() string {
+	return fmt.Sprintf("Required field not found in k8s Secret | field='%s'", e.RequiredFieldName)
+}
+
+func (e *credentialNotFoundInK8sSecretError) Is(target error) bool {
+	return target == ErrCredentialNotFoundInK8sSecret
+}

--- a/internal/controller/authenticator_test.go
+++ b/internal/controller/authenticator_test.go
@@ -139,7 +139,7 @@ func (suite *ControllerTestSuite) TestReadCredentialsK8sSecrets() {
 				}
 			}
 
-			clientID, clientSecret, err := authn.ReadCredentialsK8sSecrets(ctx, tt.secretName)
+			clientID, clientSecret, err := authn.ReadCredentialsK8sSecrets(ctx, tt.secretName, false)
 			if tt.expectedError {
 				assert.Error(suite.T(), err)
 				assert.EqualErrorf(suite.T(), err, tt.expectedErrMsg, "Error should be: %v, got: %v", tt.expectedErrMsg, err)

--- a/internal/controller/authenticator_test.go
+++ b/internal/controller/authenticator_test.go
@@ -92,8 +92,8 @@ func (suite *ControllerTestSuite) TestReadCredentialsK8sSecrets() {
 		"success": {
 			secretName: "test-secret",
 			secretData: map[string][]byte{
-				"client_id":     []byte("test-client-id"),
-				"client_secret": []byte("test-client-secret"),
+				string(ONBOARDING_CLIENT_ID):     []byte("test-client-id"),
+				string(ONBOARDING_CLIENT_SECRET): []byte("test-client-secret"),
 			},
 			expectedError:        false,
 			expectedClientID:     "test-client-id",
@@ -107,18 +107,18 @@ func (suite *ControllerTestSuite) TestReadCredentialsK8sSecrets() {
 		"client-id-not-found": {
 			secretName: "test-secret-no-client-id",
 			secretData: map[string][]byte{
-				"client_secret": []byte("test-client-secret"),
+				string(ONBOARDING_CLIENT_SECRET): []byte("test-client-secret"),
 			},
 			expectedError:  true,
-			expectedErrMsg: "failed to get client_id from secret",
+			expectedErrMsg: NewCredentialNotFoundInK8sSecretError(ONBOARDING_CLIENT_ID).Error(),
 		},
 		"client-secret-not-found": {
 			secretName: "test-secret-no-client-secret-id",
 			secretData: map[string][]byte{
-				"client_id": []byte("test-client-id"),
+				string(ONBOARDING_CLIENT_ID): []byte("test-client-id"),
 			},
 			expectedError:  true,
-			expectedErrMsg: "failed to get client_secret from secret",
+			expectedErrMsg: NewCredentialNotFoundInK8sSecretError(ONBOARDING_CLIENT_SECRET).Error(),
 		},
 	}
 
@@ -139,7 +139,7 @@ func (suite *ControllerTestSuite) TestReadCredentialsK8sSecrets() {
 				}
 			}
 
-			clientID, clientSecret, err := authn.ReadCredentialsK8sSecrets(ctx, tt.secretName, false)
+			clientID, clientSecret, err := authn.ReadCredentialsK8sSecrets(ctx, tt.secretName)
 			if tt.expectedError {
 				assert.Error(suite.T(), err)
 				assert.EqualErrorf(suite.T(), err, tt.expectedErrMsg, "Error should be: %v, got: %v", tt.expectedErrMsg, err)

--- a/internal/controller/onboarding.go
+++ b/internal/controller/onboarding.go
@@ -16,12 +16,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Credentials contains attributes that are needed for onboarding.
-type Credentials struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-}
-
 type OnboardResponse struct {
 	ClusterClientId     string `json:"cluster_client_id"`
 	ClusterClientSecret string `json:"cluster_client_secret"`

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -556,15 +556,16 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 func NewAuthenticatedConnection(ctx context.Context, logger *zap.SugaredLogger, envMap EnvironmentConfig) (*grpc.ClientConn, pb.KubernetesInfoServiceClient, error) {
 	authn := Authenticator{Logger: logger}
 
-	clientID, clientSecret, err := authn.ReadCredentialsK8sSecrets(ctx, envMap.ClusterCreds, true)
-	if err != nil {
-		if errors.Is(err, ErrSecretUnpopulated) {
-			logger.Debug("Secret is not populated yet", "error", err)
-		} else {
-			logger.Errorw("Could not read K8s credentials", "error", err)
-		}
+	clientID, clientSecret, err := authn.ReadCredentialsK8sSecrets(ctx, envMap.ClusterCreds)
+	if errors.Is(err, ErrCredentialNotFoundInK8sSecret) {
+		logger.Debugw("Secret is not populated yet", "error", err)
+	} else if err != nil {
+		logger.Errorw("Could not read K8s credentials", "error", err)
 	}
 
+	// At the end of this block, have the clientID and clientSecret variables
+	// populated. If not, we should have returned. A comment like this is
+	// code-smell, meaning that this block should be hoisted to a function
 	if clientID == "" && clientSecret == "" {
 		OnboardingCredentials, err := authn.GetOnboardingCredentials(ctx, envMap.OnboardingClientId, envMap.OnboardingClientSecret)
 		if err != nil {
@@ -579,11 +580,27 @@ func NewAuthenticatedConnection(ctx context.Context, logger *zap.SugaredLogger, 
 		if err != nil {
 			logger.Errorw("Failed to write secret to Kubernetes", "error", err)
 		}
-		// Sleeping just so k8s can finish writing the secret before we read from it.
-		time.Sleep(1 * time.Second)
-		clientID, clientSecret, err = authn.ReadCredentialsK8sSecrets(ctx, envMap.ClusterCreds, false)
+
+		// k8s may take some time writing the secret. Here we will try 'maxRetries'
+		// times, waiting 'waitDuration' seconds between each try. Even a single 1
+		// second wait is probably fine, but just to be semantic this wait is done
+		// as a poll.
+		maxRetries := 5
+		waitDuration := 1 * time.Second
+		for i := 0; i < maxRetries; i++ {
+			clientID, clientSecret, err = authn.ReadCredentialsK8sSecrets(ctx, envMap.ClusterCreds)
+			if errors.Is(err, ErrCredentialNotFoundInK8sSecret) {
+				logger.Debugw("Secret is not populated yet", "error", err)
+			}
+			if clientID != "" && clientSecret != "" {
+				err = nil
+				break
+			}
+			time.Sleep(waitDuration)
+		}
 		if err != nil {
 			logger.Errorw("Could not read K8s credentials", "error", err)
+			return nil, nil, err
 		}
 	}
 	conn, err := SetUpOAuthConnection(ctx, logger, envMap.TokenEndpoint, envMap.TlsSkipVerify, clientID, clientSecret)


### PR DESCRIPTION
This is a hacky way to do what I want to do. I will raise another competing PR that makes a bigger diff but respects im/purity more.