### PR TITLE
Fix gops binary

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,8 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 
 # Install kubectl
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    rm -f kubectl
 
 # Install Helm
 RUN curl -fsSL -o /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,8 +32,7 @@ RUN curl -fsSL -o /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linu
     tar -zxvf /tmp/helm.tar.gz -C /tmp && \
     ls -l /tmp && \
     ls -l /tmp/linux-amd64 && \
-    mv /tmp/linux-amd64/helm /usr/local/bin/helm && \
-    chmod +x /usr/local/bin/helm && \
+    install -o root -g root -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm && \
     rm -rf /tmp/helm.tar.gz /tmp/linux-amd64 && \
     helm completion bash > /etc/bash_completion.d/helm
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,9 +23,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_VERSION}
 
 # Install kubectl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    rm -f kubectl
+RUN curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl && \
+    rm -f /tmp/kubectl
 
 # Install Helm
 RUN curl -fsSL -o /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_VERSION}
 
+# Install kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
 # Install Helm
 RUN curl -fsSL -o /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
     tar -zxvf /tmp/helm.tar.gz -C /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ ARG TARGETARCH
 WORKDIR /workspace
 
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY go.mod go.sum ./
 
 # Cache dependencies before copying the source to avoid re-downloading
 RUN go mod download
@@ -18,21 +17,22 @@ COPY cmd/main.go cmd/main.go
 COPY internal/controller/ internal/controller/
 COPY internal/version/ internal/version/
 COPY api/ api/
-# Build
 
+# Build the Go binary
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X 'github.com/illumio/cloud-operator/internal/version.version=${VERSION}'" -a -o manager cmd/main.go
 
-# Install debugging tools (including bash) and gops for troubleshooting
+# Install gops for troubleshooting
 RUN go install github.com/google/gops@latest
 
 # Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 
-# Copy the manager binary and gops (from the builder)
+# Set up gops configuration and copy binaries
+ENV GOPS_CONFIG_DIR="/var/run/gops"
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --from=builder /go/bin/gops .
+COPY --from=builder /go/bin/gops /bin/gops
+
 USER 65532:65532
 
 # Set the entrypoint for your app

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-X 'github.com/illumio/cloud-operator/inter
 RUN CGO_ENABLED=0 go install github.com/google/gops@latest
 
 # Use distroless as minimal base image to package the manager binary
-FROM gcr.io/distroless/static:debug-nonroot
+FROM gcr.io/distroless/static:nonroot
 
 # Copy binaries
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM gcr.io/distroless/static:debug-nonroot
 # Copy binaries
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --from=builder /go/bin/gops .
+COPY --from=builder /go/bin/gops /sbin/gops
 
 USER 65532:65532
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,15 @@ RUN go install github.com/google/gops@latest
 # Use distroless as minimal base image to package the manager binary
 FROM gcr.io/distroless/static:debug-nonroot
 
-# Set up gops configuration and copy binaries
-ENV GOPS_CONFIG_DIR="/var/run/gops"
+# Copy binaries
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /go/bin/gops /bin/gops
 
 USER 65532:65532
+
+# Configure gops
+ENV GOPS_CONFIG_DIR="/var/run/gops"
 
 # Set the entrypoint for your app
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ COPY internal/version/ internal/version/
 COPY api/ api/
 
 # Build the Go binary
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X 'github.com/illumio/cloud-operator/internal/version.version=${VERSION}'" -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 go build -ldflags="-X 'github.com/illumio/cloud-operator/internal/version.version=${VERSION}'" -a -o manager cmd/main.go
 
 # Install gops for troubleshooting
-RUN go install github.com/google/gops@latest
+RUN CGO_ENABLED=0 go install github.com/google/gops@latest
 
 # Use distroless as minimal base image to package the manager binary
 FROM gcr.io/distroless/static:debug-nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM gcr.io/distroless/static:debug-nonroot
 # Copy binaries
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --from=builder /go/bin/gops /bin/gops
+COPY --from=builder /go/bin/gops .
 
 USER 65532:65532
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags
 RUN go install github.com/google/gops@latest
 
 # Use distroless as minimal base image to package the manager binary
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:debug-nonroot
 
 # Set up gops configuration and copy binaries
 ENV GOPS_CONFIG_DIR="/var/run/gops"

--- a/cloud-operator.image.yaml
+++ b/cloud-operator.image.yaml
@@ -1,3 +1,4 @@
 image:
   repository: "host.docker.internal:5000/operator"
   tag: "latest"
+  pullPolicy: Always

--- a/cloud-operator/templates/cloud-operator-deployment.yaml
+++ b/cloud-operator/templates/cloud-operator-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       securityContext:
+        readOnlyRootFilesystem: true
         fsGroup: 65532
       priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
@@ -86,3 +87,11 @@ spec:
                   fieldPath: metadata.namespace
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: gops-volume
+              mountPath: /var/run/gops
+      volumes:
+        - name: gops-volume
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Mi 

--- a/cloud-operator/templates/cloud-operator-deployment.yaml
+++ b/cloud-operator/templates/cloud-operator-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         release: {{ .Release.Name }}
     spec:
       securityContext:
-        readOnlyRootFilesystem: true
         fsGroup: 65532
       priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/cloud-operator/templates/cloud-operator-service.yaml
+++ b/cloud-operator/templates/cloud-operator-service.yaml
@@ -1,3 +1,5 @@
+# Copyright 2024 Illumio, Inc. All Rights Reserved.
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/cloud-operator/templates/networkpolicy.yaml
+++ b/cloud-operator/templates/networkpolicy.yaml
@@ -1,3 +1,5 @@
+# Copyright 2024 Illumio, Inc. All Rights Reserved.
+
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/cloud-operator/values.yaml
+++ b/cloud-operator/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 priorityClassName: ""
 image:
   repository: "ghcr.io/illumio/cloud-operator"
-  tag: "pr-137"
+  tag: "0.0.1"
   pullPolicy: IfNotPresent
 
 serviceAccount:

--- a/cloud-operator/values.yaml
+++ b/cloud-operator/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 priorityClassName: ""
 image:
   repository: "ghcr.io/illumio/cloud-operator"
-  tag: "0.0.1"
+  tag: "pr-137"
   pullPolicy: IfNotPresent
 
 serviceAccount:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -112,7 +112,6 @@ func main() {
 		},
 		PodNamespace: viper.GetString("pod_namspace"),
 	}
-
 	logger.Info("Starting application",
 		zap.String("cluster_creds_secret", envConfig.ClusterCreds),
 		zap.String("cilium_namespace", envConfig.CiliumNamespace),
@@ -127,10 +126,11 @@ func main() {
 		zap.Duration("stream_keepalive_period_configuration", envConfig.KeepalivePeriods.Configuration),
 	)
 
-	// Start the gops agent and listen on a specific address and port
+	// Start the gops agent
 	if err := agent.Listen(agent.Options{}); err != nil {
 		logger.Error("Failed to start gops agent", zap.Error(err))
 	}
+
 	http.HandleFunc("/healthz", newHealthHandler(controller.ServerIsHealthy))
 	healthChecker := &http.Server{Addr: ":8080"}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -112,6 +112,7 @@ func main() {
 		},
 		PodNamespace: viper.GetString("pod_namspace"),
 	}
+
 	logger.Info("Starting application",
 		zap.String("cluster_creds_secret", envConfig.ClusterCreds),
 		zap.String("cilium_namespace", envConfig.CiliumNamespace),


### PR DESCRIPTION
Build `gops` as a static binary.
Install `gops` into `/sbin` in the Docker image.
Set `GOPS_CONFIG_DIR` to `/var/run/gops` to contain the gops Unix Domain Sockets.
Mount an empty dir at `/var/run/gops` to make it writeable, as the rest of the filesystem is read-only.