### PR TITLE
Fix for Cilium and Falco disconnections and failures to reconnect

### DIFF
--- a/internal/controller/flow_cilium.go
+++ b/internal/controller/flow_cilium.go
@@ -198,21 +198,18 @@ func (fm *CiliumFlowCollector) exportCiliumFlows(ctx context.Context, sm streamM
 // convertCiliumFlow converts a GetFlowsResponse object to a CiliumFlow object
 func convertCiliumFlow(flow *observer.GetFlowsResponse) *pb.CiliumFlow {
 	flowObj := flow.GetFlow()
-
 	// Check for nil fields
 	if flowObj.GetTime() == nil ||
 		flowObj.GetNodeName() == "" ||
 		flowObj.GetTrafficDirection().String() == "" ||
 		flowObj.GetVerdict().String() == "" ||
 		flowObj.GetIP() == nil ||
-		flowObj.GetL4() == nil ||
-		flowObj.GetDestinationService() == nil {
-
+		flowObj.GetL4() == nil {
 		// Return nil if any of the essential fields are nil
 		return nil
 	}
 
-	ciliumFlow := pb.CiliumFlow{
+	ciliumFlow := &pb.CiliumFlow{
 		Time:               flowObj.GetTime(),
 		NodeName:           flowObj.GetNodeName(),
 		Verdict:            pb.Verdict(flowObj.GetVerdict()),
@@ -246,5 +243,5 @@ func convertCiliumFlow(flow *observer.GetFlowsResponse) *pb.CiliumFlow {
 			Workloads:   convertCiliumWorkflows(flowObj.GetDestination().GetWorkloads()),
 		}
 	}
-	return &ciliumFlow
+	return ciliumFlow
 }

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -211,6 +211,7 @@ func (sm *streamManager) StreamLogs(ctx context.Context) error {
 	return nil
 }
 
+// hubbleRelayDiscoery checks if hubble relay exists and if it does it returns a *CiliumFlowCollector
 func (sm *streamManager) hubbleRelayDiscovery(ctx context.Context, ciliumNamespace string) (*CiliumFlowCollector, bool) {
 	// TODO: Add logic for a discoveribility function to decide which CNI to use.
 	ciliumFlowCollector, err := newCiliumFlowCollector(ctx, sm.logger, ciliumNamespace)
@@ -225,7 +226,7 @@ func (sm *streamManager) hubbleRelayDiscovery(ctx context.Context, ciliumNamespa
 func (sm *streamManager) StreamCiliumNetworkFlows(ctx context.Context, ciliumNamespace string) error {
 	// TODO: Add logic for a discoveribility function to decide which CNI to use.
 	ciliumFlowCollector, ok := sm.hubbleRelayDiscovery(ctx, ciliumNamespace)
-	if ok != true {
+	if !ok {
 		sm.logger.Info("Failed to initialize Cilium Hubble Relay flow collector; disabling flow collector")
 		return fmt.Errorf("hubble relay cannot be found")
 	}

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -5,7 +5,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/rand"
 	"net"
 	"net/http"
@@ -211,8 +210,8 @@ func (sm *streamManager) StreamLogs(ctx context.Context) error {
 	return nil
 }
 
-// hubbleRelayDiscoery checks if hubble relay exists and if it does it returns a *CiliumFlowCollector
-func (sm *streamManager) hubbleRelayDiscovery(ctx context.Context, ciliumNamespace string) (*CiliumFlowCollector, bool) {
+// findHubbleRelay returns a *CiliumFlowCollector if hubble relay is found in the given namespace
+func (sm *streamManager) findHubbleRelay(ctx context.Context, ciliumNamespace string) (*CiliumFlowCollector, bool) {
 	// TODO: Add logic for a discoveribility function to decide which CNI to use.
 	ciliumFlowCollector, err := newCiliumFlowCollector(ctx, sm.logger, ciliumNamespace)
 	if err != nil {
@@ -228,7 +227,7 @@ func (sm *streamManager) StreamCiliumNetworkFlows(ctx context.Context, ciliumNam
 	ciliumFlowCollector, ok := sm.hubbleRelayDiscovery(ctx, ciliumNamespace)
 	if !ok {
 		sm.logger.Info("Failed to initialize Cilium Hubble Relay flow collector; disabling flow collector")
-		return fmt.Errorf("hubble relay cannot be found")
+		return errors.New("hubble relay cannot be found")
 	}
 	if ciliumFlowCollector != nil {
 		for {

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -215,7 +215,6 @@ func (sm *streamManager) findHubbleRelay(ctx context.Context, ciliumNamespace st
 	// TODO: Add logic for a discoveribility function to decide which CNI to use.
 	ciliumFlowCollector, err := newCiliumFlowCollector(ctx, sm.logger, ciliumNamespace)
 	if err != nil {
-		sm.streamClient.disableNetworkFlowsCilium = true
 		return nil
 	}
 	return ciliumFlowCollector
@@ -517,7 +516,6 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 			} else {
 				sm.streamClient.disableNetworkFlowsCilium = false
 			}
-			sm.findHubbleRelay(ctx, sm.streamClient.ciliumNamespace)
 
 			resourceDone := make(chan struct{})
 			logDone := make(chan struct{})

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -224,7 +224,7 @@ func (sm *streamManager) findHubbleRelay(ctx context.Context, ciliumNamespace st
 // StreamCiliumNetworkFlows handles the cilium network flow stream.
 func (sm *streamManager) StreamCiliumNetworkFlows(ctx context.Context, ciliumNamespace string) error {
 	// TODO: Add logic for a discoveribility function to decide which CNI to use.
-	ciliumFlowCollector, ok := sm.hubbleRelayDiscovery(ctx, ciliumNamespace)
+	ciliumFlowCollector, ok := sm.findHubbleRelay(ctx, ciliumNamespace)
 	if !ok {
 		sm.logger.Info("Failed to initialize Cilium Hubble Relay flow collector; disabling flow collector")
 		return errors.New("hubble relay cannot be found")
@@ -514,7 +514,7 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 				bufferedGrpcSyncer: bufferedGrpcSyncer,
 			}
 
-			sm.hubbleRelayDiscovery(ctx, sm.streamClient.ciliumNamespace)
+			sm.findHubbleRelay(ctx, sm.streamClient.ciliumNamespace)
 
 			resourceDone := make(chan struct{})
 			logDone := make(chan struct{})

--- a/internal/controller/streams_helper.go
+++ b/internal/controller/streams_helper.go
@@ -33,6 +33,7 @@ func sendObjectData(sm *streamManager, metadata *pb.KubernetesObjectData) error 
 // sendNetworkFlowRequest sends a network flow to the networkFlowsStream
 func sendNetworkFlowRequest(sm *streamManager, flow interface{}) error {
 	var request *pb.SendKubernetesNetworkFlowsRequest
+
 	switch f := flow.(type) {
 	case *pb.FalcoFlow:
 		request = &pb.SendKubernetesNetworkFlowsRequest{

--- a/internal/controller/streams_helper.go
+++ b/internal/controller/streams_helper.go
@@ -33,7 +33,6 @@ func sendObjectData(sm *streamManager, metadata *pb.KubernetesObjectData) error 
 // sendNetworkFlowRequest sends a network flow to the networkFlowsStream
 func sendNetworkFlowRequest(sm *streamManager, flow interface{}) error {
 	var request *pb.SendKubernetesNetworkFlowsRequest
-
 	switch f := flow.(type) {
 	case *pb.FalcoFlow:
 		request = &pb.SendKubernetesNetworkFlowsRequest{


### PR DESCRIPTION
Changes for Cilium flows

- Get rid of complicated wait groups and just check for hubble before we check whether to use cilium or falco
- Get rid of the destination service as a requirement (dropping most flows since most do not have this filled in)

Changes for Falco flows

- Do not return if an incomplete falco log is consumed. Instead just read next one and ignore current one.
