### PR TITLE
Fix gRPC logger to log structured fields

### DIFF
--- a/internal/controller/authenticator_test.go
+++ b/internal/controller/authenticator_test.go
@@ -28,7 +28,7 @@ func (suite *ControllerTestSuite) TestGetOnboardingCredentials() {
 	core := zapcore.NewTee(
 		zapcore.NewCore(encoder, consoleSyncer, zapcore.InfoLevel),
 	)
-	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1)).Sugar()
+	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
 	logger = logger.With(zap.String("name", "test"))
 
 	tests := map[string]struct {
@@ -78,7 +78,7 @@ func (suite *ControllerTestSuite) TestReadCredentialsK8sSecrets() {
 	core := zapcore.NewTee(
 		zapcore.NewCore(encoder, consoleSyncer, zapcore.InfoLevel),
 	)
-	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1)).Sugar()
+	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
 	logger = logger.With(zap.String("name", "test"))
 
 	tests := map[string]struct {

--- a/internal/controller/flow_cilium.go
+++ b/internal/controller/flow_cilium.go
@@ -19,7 +19,7 @@ import (
 
 // CiliumFlowCollector collects flows from Cilium Hubble Relay running in this cluster.
 type CiliumFlowCollector struct {
-	logger *zap.SugaredLogger
+	logger *zap.Logger
 	client observer.ObserverClient
 }
 
@@ -49,7 +49,7 @@ func discoverCiliumHubbleRelayAddress(ctx context.Context, ciliumNamespace strin
 }
 
 // newCiliumCollector connects to Ciilium Hubble Relay, sets up an Observer client, and returns a new Collector using it.
-func newCiliumFlowCollector(ctx context.Context, logger *zap.SugaredLogger, ciliumNamespace string) (*CiliumFlowCollector, error) {
+func newCiliumFlowCollector(ctx context.Context, logger *zap.Logger, ciliumNamespace string) (*CiliumFlowCollector, error) {
 	config, err := NewClientSet()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new client set: %w", err)
@@ -163,13 +163,13 @@ func (fm *CiliumFlowCollector) exportCiliumFlows(ctx context.Context, sm streamM
 	observerClient := fm.client
 	stream, err := observerClient.GetFlows(ctx, req)
 	if err != nil {
-		fm.logger.Errorw("Error getting network flows", "error", err)
+		fm.logger.Error("Error getting network flows", zap.Error(err))
 		return err
 	}
 	defer func() {
 		err = stream.CloseSend()
 		if err != nil {
-			fm.logger.Errorw("Error closing observerClient stream", "error", err)
+			fm.logger.Error("Error closing observerClient stream", zap.Error(err))
 		}
 	}()
 	for {
@@ -180,7 +180,7 @@ func (fm *CiliumFlowCollector) exportCiliumFlows(ctx context.Context, sm streamM
 		}
 		flow, err := stream.Recv()
 		if err != nil {
-			fm.logger.Warnw("Failed to get flow log from stream", "error", err)
+			fm.logger.Warn("Failed to get flow log from stream", zap.Error(err))
 			return err
 		}
 		ciliumFlow := convertCiliumFlow(flow)
@@ -189,7 +189,7 @@ func (fm *CiliumFlowCollector) exportCiliumFlows(ctx context.Context, sm streamM
 		}
 		err = sendNetworkFlowRequest(&sm, ciliumFlow)
 		if err != nil {
-			fm.logger.Errorw("Cannot send cilium flow", "error", err)
+			fm.logger.Error("Cannot send cilium flow", zap.Error(err))
 			return err
 		}
 	}

--- a/internal/controller/grpc_logger.go
+++ b/internal/controller/grpc_logger.go
@@ -302,17 +302,15 @@ func NewGRPCLogger(grpcSyncer *BufferedGrpcWriteSyncer, addCaller bool, clock za
 	consoleCore := zapcore.NewCore(encoder, consoleSyncer, atomicLevel)
 
 	// Create zap logger with the console core
-	logger := zap.New(consoleCore,
+	logger := zap.New(
+		&zapCoreWrapper{
+			core:       consoleCore,
+			encoder:    encoder,
+			grpcSyncer: grpcSyncer,
+		},
 		zap.WithCaller(addCaller),
 		zap.AddStacktrace(zapcore.ErrorLevel),
 		zap.WithClock(clock),
-		zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-			return &zapCoreWrapper{
-				core:       core,
-				encoder:    encoder,
-				grpcSyncer: grpcSyncer,
-			}
-		}),
 	)
 
 	grpcSyncer.logger = logger

--- a/internal/controller/grpc_logger.go
+++ b/internal/controller/grpc_logger.go
@@ -182,7 +182,6 @@ func (b *BufferedGrpcWriteSyncer) UpdateClient(client pb.KubernetesInfoService_S
 	b.mutex.Lock()
 	b.client = client
 	b.conn = conn
-	b.done = make(chan struct{})
 	b.flush()
 	b.mutex.Unlock()
 }

--- a/internal/controller/grpc_logger.go
+++ b/internal/controller/grpc_logger.go
@@ -130,7 +130,7 @@ func (b *BufferedGrpcWriteSyncer) run() {
 func encodeLogEntry(encoder zapcore.Encoder, logEntry zapcore.Entry, fields []zap.Field) (string, error) {
 	buf, err := encoder.EncodeEntry(logEntry, fields)
 	if err != nil {
-		return "", fmt.Errorf("Failed to encode log entry: %w", err)
+		return "", fmt.Errorf("failed to encode log entry: %w", err)
 	}
 
 	// Remove any newline added by Zap's encoder

--- a/internal/controller/grpc_logger.go
+++ b/internal/controller/grpc_logger.go
@@ -100,8 +100,8 @@ func (b *BufferedGrpcWriteSyncer) flush() {
 		b.lostLogEntriesCount = 0
 	}
 
-	for _, logEntry := range b.buffer {
-		if err := b.sendLogEntry(logEntry); err != nil {
+	for _, jsonMessage := range b.buffer {
+		if err := b.sendLogEntry(jsonMessage); err != nil {
 			b.lostLogEntriesCount += 1
 			b.lostLogEntriesErr = err
 		}

--- a/internal/controller/k8s_resources.go
+++ b/internal/controller/k8s_resources.go
@@ -46,7 +46,7 @@ func getObjectMetadataFromRuntimeObject(obj runtime.Object) (*metav1.ObjectMeta,
 
 // getMetadatafromResource extracts the metav1.ObjectMeta from an unstructured.Unstructured resource.
 // It utilizes the unstructured's inherent methods to access the metadata directly.
-func getMetadatafromResource(logger *zap.SugaredLogger, resource unstructured.Unstructured) (*metav1.ObjectMeta, error) {
+func getMetadatafromResource(logger *zap.Logger, resource unstructured.Unstructured) (*metav1.ObjectMeta, error) {
 	// Convert unstructured object to a map.
 	itemMap := resource.Object
 	// Extract metadata from map.
@@ -54,12 +54,12 @@ func getMetadatafromResource(logger *zap.SugaredLogger, resource unstructured.Un
 		// Convert the metadata map to JSON and then unmarshal into metav1.ObjectMeta.
 		metadataJSON, err := json.Marshal(metadata)
 		if err != nil {
-			logger.Errorw("Error marshalling metadata", "error", err)
+			logger.Error("Error marshalling metadata", zap.Error(err))
 			return &metav1.ObjectMeta{}, err
 		}
 		var objectMeta metav1.ObjectMeta
 		if err := json.Unmarshal(metadataJSON, &objectMeta); err != nil {
-			logger.Errorw("Error unmarshalling metadata", "error", err)
+			logger.Error("Error unmarshalling metadata", zap.Error(err))
 			return &metav1.ObjectMeta{}, err
 		}
 		return &objectMeta, err
@@ -69,10 +69,10 @@ func getMetadatafromResource(logger *zap.SugaredLogger, resource unstructured.Un
 }
 
 // convertMetaObjectToMetadata takes a metav1.ObjectMeta and converts it into a proto message object KubernetesMetadata.
-func convertMetaObjectToMetadata(logger *zap.SugaredLogger, ctx context.Context, obj metav1.ObjectMeta, clientset *kubernetes.Clientset, resource string) (*pb.KubernetesObjectData, error) {
+func convertMetaObjectToMetadata(logger *zap.Logger, ctx context.Context, obj metav1.ObjectMeta, clientset *kubernetes.Clientset, resource string) (*pb.KubernetesObjectData, error) {
 	ownerReferences, err := convertOwnerReferences(obj.GetOwnerReferences())
 	if err != nil {
-		logger.Errorw("cannot convert OwnerReferences", "error", err)
+		logger.Error("cannot convert OwnerReferences", zap.Error(err))
 		return &pb.KubernetesObjectData{}, fmt.Errorf("cannot convert OwnerReferences")
 	}
 	objMetadata := &pb.KubernetesObjectData{

--- a/internal/controller/k8s_resources_test.go
+++ b/internal/controller/k8s_resources_test.go
@@ -58,10 +58,10 @@ func (suite *ControllerTestSuite) TestConvertObjectToMetadata() {
 		UID:             "test-uid",
 		ResourceVersion: "test-version",
 	}
-	logger := zap.NewNop().Sugar()
+	logger := zap.NewNop()
 	clientset, err := NewClientSet()
 	if err != nil {
-		logger.Errorw("Failed to create clientset", "error", err)
+		logger.Error("Failed to create clientset", zap.Error(err))
 		suite.T().Error("could not create clientset")
 	}
 	// Execute the function under test.
@@ -145,7 +145,7 @@ func TestGetObjectMetadataFromRuntimeObject(t *testing.T) {
 
 func TestGetMetadataFromResource(t *testing.T) {
 	// Create a no-op logger.
-	logger := zap.NewNop().Sugar()
+	logger := zap.NewNop()
 
 	// Create an `unstructured.Unstructured` object with metadata.
 	resource := unstructured.Unstructured{
@@ -172,11 +172,11 @@ func TestGetMetadataFromResource(t *testing.T) {
 }
 
 func (suite *ControllerTestSuite) TestConvertMetaObjectToMetadata() {
-	logger := zap.NewNop().Sugar()
+	logger := zap.NewNop()
 
 	clientset, err := NewClientSet()
 	if err != nil {
-		logger.Errorw("Failed to create clientset", "error", err)
+		logger.Error("Failed to create clientset", zap.Error(err))
 		suite.T().Fatalf("could not create clientset: %v", err)
 	}
 

--- a/internal/controller/onboarding.go
+++ b/internal/controller/onboarding.go
@@ -22,7 +22,7 @@ type OnboardResponse struct {
 }
 
 // Onboard onboards this cluster with CloudSecure using the onboarding credentials and obtains OAuth 2 credentials for this cluster.
-func Onboard(ctx context.Context, TlsSkipVerify bool, OnboardingEndpoint string, credentials Credentials, logger *zap.SugaredLogger) (OnboardResponse, error) {
+func Onboard(ctx context.Context, TlsSkipVerify bool, OnboardingEndpoint string, credentials Credentials, logger *zap.Logger) (OnboardResponse, error) {
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: TlsSkipVerify,
@@ -45,14 +45,14 @@ func Onboard(ctx context.Context, TlsSkipVerify bool, OnboardingEndpoint string,
 	// Convert the data to JSON
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		logger.Errorw("Unable to marshal json data", "error", err)
+		logger.Error("Unable to marshal json data", zap.Error(err))
 		return responseData, err
 	}
 
 	// Create a new POST request with the JSON data
 	req, err := http.NewRequest("POST", OnboardingEndpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
-		logger.Errorw("Unable to structure post request", "error", err)
+		logger.Error("Unable to structure post request", zap.Error(err))
 		return responseData, err
 	}
 
@@ -60,7 +60,7 @@ func Onboard(ctx context.Context, TlsSkipVerify bool, OnboardingEndpoint string,
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
-		logger.Errorw("Unable to send post request", "error", err)
+		logger.Error("Unable to send post request", zap.Error(err))
 		return responseData, err
 	}
 
@@ -70,27 +70,27 @@ func Onboard(ctx context.Context, TlsSkipVerify bool, OnboardingEndpoint string,
 	case http.StatusUnauthorized:
 		// 401 Unauthorized
 		err := errors.New("unauthorized: invalid credentials")
-		logger.Errorw("Received 401 Unauthorized",
-			"error", err,
-			"status_code", 401,
-			"description", "invalid credentials",
+		logger.Error("Received 401 Unauthorized",
+			zap.Error(err),
+			zap.Int("status_code", http.StatusUnauthorized),
+			zap.String("description", "invalid credentials"),
 		)
 		return responseData, err
 	case http.StatusInternalServerError:
 		// 500 Internal Server Error
 		err := errors.New("internal server error: something went wrong on the server")
-		logger.Errorw("Received 500 Internal Server Error",
-			"error", err,
-			"status_code", http.StatusInternalServerError,
-			"description", "something went wrong on the server",
+		logger.Error("Received 500 Internal Server Error",
+			zap.Error(err),
+			zap.Int("status_code", http.StatusInternalServerError),
+			zap.String("description", "something went wrong on the server"),
 		)
 		return responseData, err
 	default:
 		// Handle other status codes
 		err := errors.New("unexpected status code")
-		logger.Errorw("Received unexpected status code",
-			"error", err,
-			"status_code", resp.StatusCode,
+		logger.Error("Received unexpected status code",
+			zap.Error(err),
+			zap.Int("status_code", resp.StatusCode),
 		)
 		return responseData, err
 	}
@@ -98,23 +98,23 @@ func Onboard(ctx context.Context, TlsSkipVerify bool, OnboardingEndpoint string,
 	// Read the response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.Errorw("Unable to read response of onboard post request", "error", err)
+		logger.Error("Unable to read response of onboard post request", zap.Error(err))
 		return responseData, err
 	}
 	if err := json.Unmarshal(body, &responseData); err != nil {
-		logger.Errorw("Unable to unmarshal json data", "error", err)
+		logger.Error("Unable to unmarshal json data", zap.Error(err))
 		return responseData, err
 	}
 	return responseData, nil
 }
 
 // getFirstAudience extracts the first audience from the claims map
-func getFirstAudience(logger *zap.SugaredLogger, claims map[string]interface{}) (string, error) {
+func getFirstAudience(logger *zap.Logger, claims map[string]interface{}) (string, error) {
 	aud, ok := claims["aud"]
 	if !ok {
 		err := errors.New("audience claim not found")
-		logger.Errorw("Error extracting audience claim",
-			"error", err,
+		logger.Error("Error extracting audience claim",
+			zap.Error(err),
 		)
 		return "", err
 	}
@@ -122,17 +122,17 @@ func getFirstAudience(logger *zap.SugaredLogger, claims map[string]interface{}) 
 	audSlice, ok := aud.([]interface{})
 	if !ok {
 		err := errors.New("audience claim is not a slice")
-		logger.Errorw("Error extracting audience claim",
-			"error", err,
-			"aud", aud,
+		logger.Error("Error extracting audience claim",
+			zap.Error(err),
+			zap.Any("aud", aud),
 		)
 		return "", err
 	}
 
 	if len(audSlice) == 0 {
 		err := errors.New("audience slice is empty")
-		logger.Errorw("Error extracting audience claim",
-			"error", err,
+		logger.Error("Error extracting audience claim",
+			zap.Error(err),
 		)
 		return "", err
 	}
@@ -140,9 +140,9 @@ func getFirstAudience(logger *zap.SugaredLogger, claims map[string]interface{}) 
 	firstAud, ok := audSlice[0].(string)
 	if !ok {
 		err := errors.New("first audience claim is not a string")
-		logger.Errorw("Error extracting audience claim",
-			"error", err,
-			"first_aud", audSlice[0],
+		logger.Error("Error extracting audience claim",
+			zap.Error(err),
+			zap.Any("first_aud", audSlice[0]),
 		)
 		return "", err
 	}
@@ -151,14 +151,14 @@ func getFirstAudience(logger *zap.SugaredLogger, claims map[string]interface{}) 
 }
 
 // GetClusterID returns the uid of the k8s cluster's kube-system namespace, which is used as the cluster's globally unique ID.
-func GetClusterID(ctx context.Context, logger *zap.SugaredLogger) (string, error) {
+func GetClusterID(ctx context.Context, logger *zap.Logger) (string, error) {
 	clientset, err := NewClientSet()
 	if err != nil {
-		logger.Errorw("Error creating clientset", "error", err)
+		logger.Error("Error creating clientset", zap.Error(err))
 	}
 	namespace, err := clientset.CoreV1().Namespaces().Get(ctx, "kube-system", v1.GetOptions{})
 	if err != nil {
-		logger.Errorw("Could not find kube-system namespace", "error", err)
+		logger.Error("Could not find kube-system namespace", zap.Error(err))
 	}
 	return string(namespace.UID), nil
 }

--- a/internal/controller/onboarding_test.go
+++ b/internal/controller/onboarding_test.go
@@ -27,7 +27,7 @@ func (suite *ControllerTestSuite) TestOnboard() {
 	core := zapcore.NewTee(
 		zapcore.NewCore(encoder, consoleSyncer, zapcore.InfoLevel),
 	)
-	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1)).Sugar()
+	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
 	logger = logger.With(zap.String("name", "test"))
 
 	tests := map[string]struct {
@@ -184,5 +184,5 @@ func (suite *ControllerTestSuite) TestGetClusterID() {
 	assert.Equal(suite.T(), expectedUID, clusterID)
 
 	// Log the cluster ID for verification
-	logger.Infow("Cluster ID", "uid", clusterID)
+	suite.T().Logf("Cluster ID: %s", clusterID)
 }

--- a/internal/controller/resource_manager.go
+++ b/internal/controller/resource_manager.go
@@ -21,7 +21,7 @@ type ResourceManager struct {
 	// Clientset providing accees to k8s api.
 	clientset *kubernetes.Clientset
 	// Logger provides strucuted logging interface.
-	logger *zap.SugaredLogger
+	logger *zap.Logger
 	// DynamicClient offers generic Kubernetes API operations.
 	dynamicClient dynamic.Interface
 	// streamManager abstracts logic related to starting, using, and managing streams.
@@ -35,7 +35,7 @@ func (r *ResourceManager) DyanmicListAndWatchResources(ctx context.Context, canc
 	resourceListVersion, err := r.DynamicListResources(ctx, resource, apiGroup)
 	if err != nil {
 		allResourcesSnapshotted.Done()
-		r.logger.Errorw("Unable to list resources", "error", err)
+		r.logger.Error("Unable to list resources", zap.Error(err))
 		cancel()
 		return
 	}
@@ -50,14 +50,14 @@ func (r *ResourceManager) DyanmicListAndWatchResources(ctx context.Context, canc
 	limiter := rate.NewLimiter(1, 5)
 	err = limiter.Wait(ctx)
 	if err != nil {
-		r.logger.Errorw("Cannot wait using rate limiter", "error", err)
+		r.logger.Error("Cannot wait using rate limiter", zap.Error(err))
 		cancel()
 		return
 	}
 
 	err = r.watchEvents(ctx, resource, apiGroup, watchOptions)
 	if err != nil {
-		r.logger.Errorw("Unable to watch events", "error", err)
+		r.logger.Error("Unable to watch events", zap.Error(err))
 		cancel()
 		return
 	}
@@ -73,12 +73,12 @@ func (r *ResourceManager) DynamicListResources(ctx context.Context, resource str
 	for _, obj := range objs {
 		metadataObj, err := convertMetaObjectToMetadata(r.logger, ctx, obj, r.clientset, resourceK8sKind)
 		if err != nil {
-			r.logger.Errorw("Cannot convert object metadata", "error", err)
+			r.logger.Error("Cannot convert object metadata", zap.Error(err))
 			return "", err
 		}
 		err = sendObjectData(r.streamManager, metadataObj)
 		if err != nil {
-			r.logger.Errorw("Cannot send object metadata", "error", err)
+			r.logger.Error("Cannot send object metadata", zap.Error(err))
 			return "", err
 		}
 	}
@@ -98,13 +98,13 @@ func (r *ResourceManager) watchEvents(ctx context.Context, resource string, apiG
 	objGVR := schema.GroupVersionResource{Group: apiGroup, Version: "v1", Resource: resource}
 	watcher, err := r.dynamicClient.Resource(objGVR).Namespace(metav1.NamespaceAll).Watch(ctx, watchOptions)
 	if err != nil {
-		r.logger.Errorw("Error setting up watch on resource", "error", err)
+		r.logger.Error("Error setting up watch on resource", zap.Error(err))
 		return err
 	}
 	for event := range watcher.ResultChan() {
 		switch event.Type {
 		case watch.Error:
-			r.logger.Errorw("Watcher event has returned an error", "error", err)
+			r.logger.Error("Watcher event has returned an error", zap.Error(err))
 			return err
 		case watch.Bookmark:
 			continue
@@ -112,18 +112,18 @@ func (r *ResourceManager) watchEvents(ctx context.Context, resource string, apiG
 		}
 		convertedData, err := getObjectMetadataFromRuntimeObject(event.Object)
 		if err != nil {
-			r.logger.Errorw("Cannot convert runtime.Object to metav1.ObjectMeta", "error", err)
+			r.logger.Error("Cannot convert runtime.Object to metav1.ObjectMeta", zap.Error(err))
 			return err
 		}
 		resource := event.Object.GetObjectKind().GroupVersionKind().Kind
 		metadataObj, err := convertMetaObjectToMetadata(r.logger, ctx, *convertedData, r.clientset, resource)
 		if err != nil {
-			r.logger.Errorw("Cannot convert object metadata", "error", err)
+			r.logger.Error("Cannot convert object metadata", zap.Error(err))
 			return err
 		}
 		err = streamMutationObjectData(r.streamManager, metadataObj, event.Type)
 		if err != nil {
-			r.logger.Errorw("Cannot send resource mutation", "error", err)
+			r.logger.Error("Cannot send resource mutation", zap.Error(err))
 			return err
 		}
 
@@ -135,7 +135,7 @@ func (r *ResourceManager) watchEvents(ctx context.Context, resource string, apiG
 func (r *ResourceManager) FetchResources(ctx context.Context, resource schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
 	unstructuredResources, err := r.dynamicClient.Resource(resource).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		r.logger.Errorw("Cannot list resource", "error", err, "kind", resource)
+		r.logger.Error("Cannot list resource", zap.Stringer("kind", resource), zap.Error(err))
 		return nil, err
 	}
 	return unstructuredResources, nil
@@ -147,7 +147,7 @@ func (r *ResourceManager) ExtractObjectMetas(resources *unstructured.Unstructure
 	for _, item := range resources.Items {
 		objMeta, err := getMetadatafromResource(r.logger, item)
 		if err != nil {
-			r.logger.Errorw("Cannot get Metadata from resource", "error", err)
+			r.logger.Error("Cannot get Metadata from resource", zap.Error(err))
 			return nil, err
 		}
 		objectMetas = append(objectMetas, *objMeta)

--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -38,7 +38,7 @@ type deadlockDetector struct {
 
 type streamManager struct {
 	bufferedGrpcSyncer *BufferedGrpcWriteSyncer
-	logger             *zap.SugaredLogger
+	logger             *zap.Logger
 	streamClient       *streamClient
 }
 
@@ -116,7 +116,7 @@ func (sm *streamManager) StreamResources(ctx context.Context, cancel context.Can
 	}()
 	clusterConfig, err := rest.InClusterConfig()
 	if err != nil {
-		sm.logger.Errorw("Error getting in-cluster config", "error", err)
+		sm.logger.Error("Error getting in-cluster config", zap.Error(err))
 		return err
 	}
 	var allResourcesSnapshotted sync.WaitGroup
@@ -124,18 +124,18 @@ func (sm *streamManager) StreamResources(ctx context.Context, cancel context.Can
 	// Create a dynamic client
 	dynamicClient, err := dynamic.NewForConfig(clusterConfig)
 	if err != nil {
-		sm.logger.Errorw("Error creating dynamic client", "error", err)
+		sm.logger.Error("Error creating dynamic client", zap.Error(err))
 		return err
 	}
 
 	clientset, err := NewClientSet()
 	if err != nil {
-		sm.logger.Errorw("Failed to create clientset", "error", err)
+		sm.logger.Error("Failed to create clientset", zap.Error(err))
 		return err
 	}
 	apiGroups, err := clientset.Discovery().ServerGroups()
 	if err != nil {
-		sm.logger.Error("Failed to discover API groups", "error", err)
+		sm.logger.Error("Failed to discover API groups", zap.Error(err))
 	}
 	foundGatewayAPIGroup := false
 
@@ -168,7 +168,7 @@ func (sm *streamManager) StreamResources(ctx context.Context, cancel context.Can
 	}
 	err = sendClusterMetadata(ctx, sm)
 	if err != nil {
-		sm.logger.Errorw("Failed to send cluster metadata", "error", err)
+		sm.logger.Error("Failed to send cluster metadata", zap.Error(err))
 		return err
 	}
 	for resource, apiGroup := range resourceAPIGroupMap {
@@ -182,7 +182,7 @@ func (sm *streamManager) StreamResources(ctx context.Context, cancel context.Can
 	dd.processingResources = false
 	dd.mutex.Unlock()
 	if err != nil {
-		sm.logger.Errorw("Failed to send resource snapshot complete", "error", err)
+		sm.logger.Error("Failed to send resource snapshot complete", zap.Error(err))
 		return err
 	}
 	snapshotCompleted.Done()
@@ -231,7 +231,7 @@ func (sm *streamManager) StreamCiliumNetworkFlows(ctx context.Context, ciliumNam
 		for {
 			err := ciliumFlowCollector.exportCiliumFlows(ctx, *sm)
 			if err != nil {
-				sm.logger.Warnw("Failed to collect and export flows from Cilium Hubble Relay", "error", err)
+				sm.logger.Warn("Failed to collect and export flows from Cilium Hubble Relay", zap.Error(err))
 				sm.streamClient.disableNetworkFlowsCilium = true
 				return err
 			}
@@ -257,12 +257,12 @@ func (sm *streamManager) StreamFalcoNetworkFlows(ctx context.Context) error {
 				// If the event has an incomplete L3/L4 layer lets just ignore it.
 				continue
 			} else if err != nil {
-				sm.logger.Errorw("Failed to parse Falco event into flow", "error", err)
+				sm.logger.Error("Failed to parse Falco event into flow", zap.Error(err))
 				return err
 			}
 			err = sendNetworkFlowRequest(sm, convertedFalcoFlow)
 			if err != nil {
-				sm.logger.Errorw("Failed to send Falco flow", "errors", err)
+				sm.logger.Error("Failed to send Falco flow", zap.Error(err))
 				return err
 			}
 		} else {
@@ -272,13 +272,13 @@ func (sm *streamManager) StreamFalcoNetworkFlows(ctx context.Context) error {
 }
 
 // connectAndStreamCiliumNetworkFlows creates networkFlowsStream client and begins the streaming of network flows.
-func connectAndStreamCiliumNetworkFlows(logger *zap.SugaredLogger, sm *streamManager) error {
+func connectAndStreamCiliumNetworkFlows(logger *zap.Logger, sm *streamManager) error {
 	ciliumCtx, ciliumCancel := context.WithCancel(context.Background())
 	defer ciliumCancel()
 
 	sendCiliumNetworkFlowsStream, err := sm.streamClient.client.SendKubernetesNetworkFlows(ciliumCtx)
 	if err != nil {
-		logger.Errorw("Failed to connect to server", "error", err)
+		logger.Error("Failed to connect to server", zap.Error(err))
 		return err
 	}
 
@@ -287,7 +287,7 @@ func connectAndStreamCiliumNetworkFlows(logger *zap.SugaredLogger, sm *streamMan
 	err = sm.StreamCiliumNetworkFlows(ciliumCtx, sm.streamClient.ciliumNamespace)
 	if err != nil {
 		if errors.Is(err, ErrHubbleNotFound) || errors.Is(err, ErrNoPortsAvailable) {
-			logger.Warnw("Disabling Cilium flow collection", "error", err)
+			logger.Warn("Disabling Cilium flow collection", zap.Error(err))
 			return ErrStopRetries
 		}
 		return err
@@ -297,12 +297,12 @@ func connectAndStreamCiliumNetworkFlows(logger *zap.SugaredLogger, sm *streamMan
 }
 
 // connectAndStreamFalcoNetworkFlows creates networkFlowsStream client and begins the streaming of network flows.
-func connectAndStreamFalcoNetworkFlows(logger *zap.SugaredLogger, sm *streamManager) error {
+func connectAndStreamFalcoNetworkFlows(logger *zap.Logger, sm *streamManager) error {
 	falcoCtx, falcoCancel := context.WithCancel(context.Background())
 	defer falcoCancel()
 	sendFalcoNetworkFlows, err := sm.streamClient.client.SendKubernetesNetworkFlows(falcoCtx)
 	if err != nil {
-		logger.Errorw("Failed to connect to server", "error", err)
+		logger.Error("Failed to connect to server", zap.Error(err))
 		return err
 	}
 
@@ -310,7 +310,7 @@ func connectAndStreamFalcoNetworkFlows(logger *zap.SugaredLogger, sm *streamMana
 
 	err = sm.StreamFalcoNetworkFlows(falcoCtx)
 	if err != nil {
-		logger.Errorw("Failed to stream Falco network flows", "error", err)
+		logger.Error("Failed to stream Falco network flows", zap.Error(err))
 		return err
 	}
 
@@ -318,13 +318,13 @@ func connectAndStreamFalcoNetworkFlows(logger *zap.SugaredLogger, sm *streamMana
 }
 
 // connectAndStreamResources creates resourceStream client and begins the streaming of resources.
-func connectAndStreamResources(logger *zap.SugaredLogger, sm *streamManager) error {
+func connectAndStreamResources(logger *zap.Logger, sm *streamManager) error {
 	resourceCtx, resourceCancel := context.WithCancel(context.Background())
 	defer resourceCancel()
 
 	SendKubernetesResourcesStream, err := sm.streamClient.client.SendKubernetesResources(resourceCtx)
 	if err != nil {
-		logger.Errorw("Failed to connect to server", "error", err)
+		logger.Error("Failed to connect to server", zap.Error(err))
 		return err
 	}
 
@@ -332,7 +332,7 @@ func connectAndStreamResources(logger *zap.SugaredLogger, sm *streamManager) err
 
 	err = sm.StreamResources(resourceCtx, resourceCancel)
 	if err != nil {
-		logger.Errorw("Failed to bootup and stream resources", "error", err)
+		logger.Error("Failed to bootup and stream resources", zap.Error(err))
 		return err
 	}
 
@@ -340,13 +340,13 @@ func connectAndStreamResources(logger *zap.SugaredLogger, sm *streamManager) err
 }
 
 // connectAndStreamLogs creates sendLogs client and begins the streaming of logs.
-func connectAndStreamLogs(logger *zap.SugaredLogger, sm *streamManager) error {
+func connectAndStreamLogs(logger *zap.Logger, sm *streamManager) error {
 	logCtx, logCancel := context.WithCancel(context.Background())
 	defer logCancel()
 
 	SendLogsStream, err := sm.streamClient.client.SendLogs(logCtx)
 	if err != nil {
-		logger.Errorw("Failed to connect to server", "error", err)
+		logger.Error("Failed to connect to server", zap.Error(err))
 		return err
 	}
 
@@ -355,7 +355,7 @@ func connectAndStreamLogs(logger *zap.SugaredLogger, sm *streamManager) error {
 
 	err = sm.StreamLogs(logCtx)
 	if err != nil {
-		logger.Errorw("Failed to bootup and stream logs", "error", err)
+		logger.Error("Failed to bootup and stream logs", zap.Error(err))
 		return err
 	}
 
@@ -363,7 +363,7 @@ func connectAndStreamLogs(logger *zap.SugaredLogger, sm *streamManager) error {
 }
 
 // Generic function to manage any stream with backoff and reconnection logic.
-func manageStream(logger *zap.SugaredLogger, connectAndStream func(*zap.SugaredLogger, *streamManager) error, sm *streamManager, done chan struct{}) {
+func manageStream(logger *zap.Logger, connectAndStream func(*zap.Logger, *streamManager) error, sm *streamManager, done chan struct{}) {
 	defer close(done)
 	const (
 		initialBackoff       = 1 * time.Second
@@ -394,7 +394,7 @@ func manageStream(logger *zap.SugaredLogger, connectAndStream func(*zap.SugaredL
 					logger.Info("Stopping retries for this stream as instructed.")
 					return
 				}
-				logger.Errorw("Failed to establish stream connection; will retry", "error", err)
+				logger.Error("Failed to establish stream connection; will retry", zap.Error(err))
 				switch {
 				case consecutiveFailures == 0:
 					resetTimer.Reset(resetPeriod)
@@ -417,7 +417,7 @@ func manageStream(logger *zap.SugaredLogger, connectAndStream func(*zap.SugaredL
 					sleep = maxBackoff
 				}
 
-				logger.Infow("Sleeping before retrying connection", "backoff", sleep)
+				logger.Info("Sleeping before retrying connection", zap.Duration("backoff", sleep))
 				sleepTimer.Reset(sleep) // Reset sleep timer with calculated backoff delay
 
 				backoff *= 2
@@ -437,7 +437,7 @@ func manageStream(logger *zap.SugaredLogger, connectAndStream func(*zap.SugaredL
 
 // ConnectStreams will continue to reboot and restart the main operations within
 // the operator if any disconnects or errors occur.
-func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap EnvironmentConfig, bufferedGrpcSyncer *BufferedGrpcWriteSyncer) {
+func ConnectStreams(ctx context.Context, logger *zap.Logger, envMap EnvironmentConfig, bufferedGrpcSyncer *BufferedGrpcWriteSyncer) {
 	// Falco channels communicate news events between http server and our network flows strea,
 	falcoEventChan := make(chan string)
 	http.HandleFunc("/", NewFalcoEventHandler(falcoEventChan))
@@ -448,16 +448,16 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 			// Create a custom listener, this listener has SO_REUSEADDR option set by default
 			listener, err := net.Listen("tcp", falcoPort)
 			if err != nil {
-				logger.Fatalf("Failed to listen on %s: %v", falcoPort, err)
+				logger.Fatal("Failed to listen on Falco port", zap.String("address", falcoPort), zap.Error(err))
 			}
 
 			// Create the HTTP server
 			falcoEvent := &http.Server{Addr: falcoPort}
 
-			logger.Infof("Falco server listening on %s", falcoPort)
+			logger.Info("Falco server listening", zap.String("address", falcoPort))
 			err = falcoEvent.Serve(listener)
 			if err != nil && err != http.ErrServerClosed {
-				logger.Errorf("Falco server failed, restarting in 5 seconds... Error: %v", err)
+				logger.Error("Falco server failed, restarting in 5 seconds", zap.Error(err))
 				// Giving some time before attempting to restart.....
 				time.Sleep(5 * time.Second)
 			}
@@ -489,7 +489,7 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 			authConContext, authConContextCancel := context.WithCancel(ctx)
 			authConn, client, err := NewAuthenticatedConnection(authConContext, logger, envMap)
 			if err != nil {
-				logger.Errorw("Failed to establish initial connection; will retry", "error", err)
+				logger.Error("Failed to establish initial connection; will retry", zap.Error(err))
 				// When we try this loop again, we wait 10 seconds with 20% jitter.
 				resetTimer.Reset(jitterTime(10*time.Second, 0.20))
 				authConContextCancel()
@@ -561,14 +561,14 @@ func ConnectStreams(ctx context.Context, logger *zap.SugaredLogger, envMap Envir
 }
 
 // NewAuthenticatedConnection gets a valid token and creats a connection to CloudSecure.
-func NewAuthenticatedConnection(ctx context.Context, logger *zap.SugaredLogger, envMap EnvironmentConfig) (*grpc.ClientConn, pb.KubernetesInfoServiceClient, error) {
+func NewAuthenticatedConnection(ctx context.Context, logger *zap.Logger, envMap EnvironmentConfig) (*grpc.ClientConn, pb.KubernetesInfoServiceClient, error) {
 	authn := Authenticator{Logger: logger}
 
 	clientID, clientSecret, err := authn.ReadCredentialsK8sSecrets(ctx, envMap.ClusterCreds)
 	if errors.Is(err, ErrCredentialNotFoundInK8sSecret) {
-		logger.Debugw("Secret is not populated yet", "error", err)
+		logger.Debug("Secret is not populated yet", zap.Error(err))
 	} else if err != nil {
-		logger.Errorw("Could not read K8s credentials", "error", err)
+		logger.Error("Could not read K8s credentials", zap.Error(err))
 	}
 
 	// At the end of this block, have the clientID and clientSecret variables
@@ -577,16 +577,16 @@ func NewAuthenticatedConnection(ctx context.Context, logger *zap.SugaredLogger, 
 	if clientID == "" && clientSecret == "" {
 		OnboardingCredentials, err := authn.GetOnboardingCredentials(ctx, envMap.OnboardingClientId, envMap.OnboardingClientSecret)
 		if err != nil {
-			logger.Errorw("Failed to get onboarding credentials", "error", err)
+			logger.Error("Failed to get onboarding credentials", zap.Error(err))
 		}
 		responseData, err := Onboard(ctx, envMap.TlsSkipVerify, envMap.OnboardingEndpoint, OnboardingCredentials, logger)
 		if err != nil {
-			logger.Errorw("Failed to register cluster", "error", err)
+			logger.Error("Failed to register cluster", zap.Error(err))
 			return nil, nil, err
 		}
 		err = authn.WriteK8sSecret(ctx, responseData, envMap.ClusterCreds)
 		if err != nil {
-			logger.Errorw("Failed to write secret to Kubernetes", "error", err)
+			logger.Error("Failed to write secret to Kubernetes", zap.Error(err))
 		}
 
 		// k8s may take some time writing the secret. Here we will try 'maxRetries'
@@ -598,7 +598,7 @@ func NewAuthenticatedConnection(ctx context.Context, logger *zap.SugaredLogger, 
 		for i := 0; i < maxRetries; i++ {
 			clientID, clientSecret, err = authn.ReadCredentialsK8sSecrets(ctx, envMap.ClusterCreds)
 			if errors.Is(err, ErrCredentialNotFoundInK8sSecret) {
-				logger.Debugw("Secret is not populated yet", "error", err)
+				logger.Debug("Secret is not populated yet", zap.Error(err))
 			}
 			if clientID != "" && clientSecret != "" {
 				err = nil
@@ -607,13 +607,13 @@ func NewAuthenticatedConnection(ctx context.Context, logger *zap.SugaredLogger, 
 			time.Sleep(waitDuration)
 		}
 		if err != nil {
-			logger.Errorw("Could not read K8s credentials", "error", err)
+			logger.Error("Could not read K8s credentials", zap.Error(err))
 			return nil, nil, err
 		}
 	}
 	conn, err := SetUpOAuthConnection(ctx, logger, envMap.TokenEndpoint, envMap.TlsSkipVerify, clientID, clientSecret)
 	if err != nil {
-		logger.Errorw("Failed to set up an OAuth connection", "error", err)
+		logger.Error("Failed to set up an OAuth connection", zap.Error(err))
 		return nil, nil, err
 	}
 

--- a/internal/controller/streams_helper.go
+++ b/internal/controller/streams_helper.go
@@ -11,9 +11,9 @@ import (
 )
 
 // Helper function to send a request to the resource stream
-func sendToResourceStream(logger *zap.SugaredLogger, stream pb.KubernetesInfoService_SendKubernetesResourcesClient, request *pb.SendKubernetesResourcesRequest) error {
+func sendToResourceStream(logger *zap.Logger, stream pb.KubernetesInfoService_SendKubernetesResourcesClient, request *pb.SendKubernetesResourcesRequest) error {
 	if err := stream.Send(request); err != nil {
-		logger.Errorw("Failed to send request", "request", request, "error", err)
+		logger.Error("Failed to send request", zap.Stringer("request", request), zap.Error(err))
 		return err
 	}
 	return nil
@@ -51,7 +51,7 @@ func sendNetworkFlowRequest(sm *streamManager, flow interface{}) error {
 		return fmt.Errorf("unsupported flow type: %T", flow)
 	}
 	if err := sm.streamClient.networkFlowsStream.Send(request); err != nil {
-		sm.logger.Errorw("Failed to send network flow", "error", err)
+		sm.logger.Error("Failed to send network flow", zap.Error(err))
 		return err
 	}
 	return nil
@@ -92,17 +92,17 @@ func streamMutationObjectData(sm *streamManager, metadata *pb.KubernetesObjectDa
 func sendClusterMetadata(ctx context.Context, sm *streamManager) error {
 	clusterUid, err := GetClusterID(ctx, sm.logger)
 	if err != nil {
-		sm.logger.Errorw("Error getting cluster id", "error", err)
+		sm.logger.Error("Error getting cluster id", zap.Error(err))
 		return err
 	}
 	clientset, err := NewClientSet()
 	if err != nil {
-		sm.logger.Errorw("Error creating clientset", "error", err)
+		sm.logger.Error("Error creating clientset", zap.Error(err))
 		return err
 	}
 	kubernetesVersion, err := clientset.Discovery().ServerVersion()
 	if err != nil {
-		sm.logger.Errorw("Error getting Kubernetes version", "error", err)
+		sm.logger.Error("Error getting Kubernetes version", zap.Error(err))
 		return err
 	}
 	request := &pb.SendKubernetesResourcesRequest{

--- a/internal/controller/suite_setup_test.go
+++ b/internal/controller/suite_setup_test.go
@@ -18,7 +18,7 @@ type ControllerTestSuite struct {
 	suite.Suite
 	ctx       context.Context
 	clientset *kubernetes.Clientset
-	logger    *zap.SugaredLogger
+	logger    *zap.Logger
 }
 
 func TestGenerateTestSuite(t *testing.T) {
@@ -79,7 +79,7 @@ func (w *LogWriter) Sync() error {
 	return nil
 }
 
-func newCustomLogger(t *testing.T) *zap.SugaredLogger {
+func newCustomLogger(t *testing.T) *zap.Logger {
 	logWriter := &LogWriter{
 		logFunc: t.Logf,
 	}
@@ -90,5 +90,5 @@ func newCustomLogger(t *testing.T) *zap.SugaredLogger {
 
 	core := zapcore.NewCore(encoder, syncWriter, zap.DebugLevel)
 
-	return zap.New(core).Sugar()
+	return zap.New(core)
 }


### PR DESCRIPTION
- Reimplement gRPC logger as a Zap Core wrapper instead of a Core hook, so it can log the structured log fields.
- Replace `SugaredLogger` with `Logger` in the whole codebase to improve efficiency and eliminate formatting bugs.
- Encode each entry into a string immediately when logged, before buffering, and never refer to the input Entry and Fields afterwards, as it is reduces the buffer's memory usage and it allows the entry and fields to be garbage-collected while a log entry is buffered.
- Fix log buffering to stop buffering when reaching the buffer capacity.
- Eliminate a channel leak by not replacing the `done` channel without closing it when updating the gRPC connection and stream client.