### PR TITLE
Upgrading Go to 1.24.2

### DIFF
--- a/.github/workflows/build_deploy_onboard.yml
+++ b/.github/workflows/build_deploy_onboard.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-            go-version: '^1.24.1'
+            go-version: '^1.24.2'
 
       - name: Install dependencies
         run: go mod tidy

--- a/.github/workflows/go-security-checks.yml
+++ b/.github/workflows/go-security-checks.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.1'
+          go-version: '^1.24.2'
 
       - name: Install dependencies
         run: go mod tidy

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.24.1'
+        go-version: '^1.24.2'
 
     - name: Install dependencies
       run: go mod tidy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.1 AS builder
+FROM golang:1.24.2 AS builder
 ARG VERSION=dev
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/illumio/cloud-operator
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/cilium/cilium v1.17.3


### PR DESCRIPTION
Upgrading Github Actions and the operator version of go to 1.24.2