### PR TITLE
Fix log message buffering

### DIFF
--- a/internal/controller/grpc_logger.go
+++ b/internal/controller/grpc_logger.go
@@ -107,10 +107,13 @@ func (b *BufferedGrpcWriteSyncer) flush() {
 		sentMessageCount += 1
 	}
 
-	// Only unbuffer the messages that could be sent and preserve the rest for the next flush()
-	newBufferLen := len(b.buffer) - sentMessageCount
-	copy(b.buffer, b.buffer[sentMessageCount:])
-	b.buffer = b.buffer[:newBufferLen]
+	// Only un-buffer the messages that were sent
+	// and keep the remaining messages buffered for the next flush()
+	if sentMessageCount > 0 {
+		newBufferLen := len(b.buffer) - sentMessageCount
+		copy(b.buffer, b.buffer[sentMessageCount:])
+		b.buffer = b.buffer[:newBufferLen]
+	}
 }
 
 // run flushes the buffer at the configured interval until Stop is called.

--- a/internal/controller/grpc_logger.go
+++ b/internal/controller/grpc_logger.go
@@ -68,7 +68,8 @@ func (b *BufferedGrpcWriteSyncer) Close() error {
 	return b.conn.Close()
 }
 
-// flush will attempt to dump buffer into GRPC stream if available
+// flush will attempt to dump buffer into GRPC stream if available.
+// Returns after the buffer is flushed or any messages failed to be sent.
 func (b *BufferedGrpcWriteSyncer) flush() {
 	if len(b.buffer) == 0 || b.conn == nil || b.conn.GetState() != connectivity.Ready {
 		return
@@ -87,24 +88,29 @@ func (b *BufferedGrpcWriteSyncer) flush() {
 				zap.Int("lost_log_entries", b.lostLogEntriesCount),
 			},
 		)
-		if err != nil {
-			b.lostLogEntriesErr = err
-			return
+		if err == nil {
+			if err := b.sendLogEntry(lostLogsMessage); err != nil {
+				b.lostLogEntriesErr = err
+				return
+			}
+			b.lostLogEntriesCount = 0
+			b.lostLogEntriesErr = nil
 		}
-		if err := b.sendLogEntry(lostLogsMessage); err != nil {
-			b.lostLogEntriesErr = err
-			return
-		}
-		b.lostLogEntriesCount = 0
 	}
 
+	sentMessageCount := 0
 	for _, jsonMessage := range b.buffer {
 		if err := b.sendLogEntry(jsonMessage); err != nil {
-			b.lostLogEntriesCount += 1
 			b.lostLogEntriesErr = err
+			break
 		}
+		sentMessageCount += 1
 	}
-	b.buffer = b.buffer[:0]
+
+	// Only unbuffer the messages that could be sent and preserve the rest for the next flush()
+	newBufferLen := len(b.buffer) - sentMessageCount
+	copy(b.buffer, b.buffer[sentMessageCount:])
+	b.buffer = b.buffer[:newBufferLen]
 }
 
 // run flushes the buffer at the configured interval until Stop is called.

--- a/internal/controller/grpc_logger_test.go
+++ b/internal/controller/grpc_logger_test.go
@@ -298,7 +298,7 @@ func (suite *BufferedGrpcWriteSyncerTestSuite) TestFlushSuccess() {
 		).MatchString(req.Request.(*pb.SendLogsRequest_LogEntry).LogEntry.JsonMessage):
 			return true
 
-		// Send buffered messages 1 and 2
+		// Send all buffered messages
 		case regexp.MustCompile(
 			`^{"level":"info","msg":"Buffered log entry [12345]"}$`,
 		).MatchString(req.Request.(*pb.SendLogsRequest_LogEntry).LogEntry.JsonMessage):

--- a/internal/controller/grpc_logger_test.go
+++ b/internal/controller/grpc_logger_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -274,4 +275,150 @@ func (suite *BufferedGrpcWriteSyncerTestSuite) TestWriteBuffering() {
 			}
 		})
 	}
+}
+
+func (suite *BufferedGrpcWriteSyncerTestSuite) TestFlushSuccess() {
+	// Simulate buffer overflow
+	suite.grpcSyncer.lostLogEntriesCount = 1234
+	suite.grpcSyncer.lostLogEntriesErr = errors.New("some buffer overflow error")
+	suite.grpcSyncer.buffer = append(
+		suite.grpcSyncer.buffer,
+		`{"level":"info","msg":"Buffered log entry 1"}`,
+		`{"level":"info","msg":"Buffered log entry 2"}`,
+		`{"level":"info","msg":"Buffered log entry 3"}`,
+		`{"level":"info","msg":"Buffered log entry 4"}`,
+		`{"level":"info","msg":"Buffered log entry 5"}`,
+	)
+
+	suite.mockClient.On("Send", mock.MatchedBy(func(req *pb.SendLogsRequest) bool {
+		switch {
+		// Send the 'Lost logs' message
+		case regexp.MustCompile(
+			`^{"level":"error","ts":[^,]*,"msg":"Lost logs due to buffer overflow","error":"some buffer overflow error","lost_log_entries":1234}$`,
+		).MatchString(req.Request.(*pb.SendLogsRequest_LogEntry).LogEntry.JsonMessage):
+			return true
+
+		// Send buffered messages 1 and 2
+		case regexp.MustCompile(
+			`^{"level":"info","msg":"Buffered log entry [12345]"}$`,
+		).MatchString(req.Request.(*pb.SendLogsRequest_LogEntry).LogEntry.JsonMessage):
+			return true
+
+		default:
+			return false
+		}
+	})).Return(nil).Times(6)
+
+	// Flush the buffer
+	suite.grpcSyncer.flush()
+
+	// Assert that lostLogEntriesCount is reset
+	suite.Equal(0, suite.grpcSyncer.lostLogEntriesCount, "lostLogEntriesCount should be reset after successfully sending 'Lost logs' message")
+	suite.Empty(suite.grpcSyncer.buffer, "Buffer should be empty after succesful flush")
+	suite.Nil(suite.grpcSyncer.lostLogEntriesErr, "lostLogEntriesErr should be nil after successfully sending 'Lost logs' message and no subsequent failure")
+}
+
+func (suite *BufferedGrpcWriteSyncerTestSuite) TestFlushPartialSuccess() {
+	// Simulate buffer overflow
+	suite.grpcSyncer.lostLogEntriesCount = 1234
+	suite.grpcSyncer.lostLogEntriesErr = errors.New("some buffer overflow error")
+	suite.grpcSyncer.buffer = append(
+		suite.grpcSyncer.buffer,
+		`{"level":"info","msg":"Buffered log entry 1"}`,
+		`{"level":"info","msg":"Buffered log entry 2"}`,
+		`{"level":"info","msg":"Buffered log entry 3"}`,
+		`{"level":"info","msg":"Buffered log entry 4"}`,
+		`{"level":"info","msg":"Buffered log entry 5"}`,
+	)
+
+	suite.mockClient.On("Send", mock.MatchedBy(func(req *pb.SendLogsRequest) bool {
+		switch {
+		// Send the 'Lost logs' message
+		case regexp.MustCompile(
+			`^{"level":"error","ts":[^,]*,"msg":"Lost logs due to buffer overflow","error":"some buffer overflow error","lost_log_entries":1234}$`,
+		).MatchString(req.Request.(*pb.SendLogsRequest_LogEntry).LogEntry.JsonMessage):
+			return true
+
+		// Send buffered messages 1 and 2
+		case regexp.MustCompile(
+			`^{"level":"info","msg":"Buffered log entry [12]"}$`,
+		).MatchString(req.Request.(*pb.SendLogsRequest_LogEntry).LogEntry.JsonMessage):
+			return true
+
+		default:
+			return false
+		}
+	})).Return(nil).Times(3)
+
+	suite.mockClient.On("Send", mock.MatchedBy(func(req *pb.SendLogsRequest) bool {
+		switch {
+		// Fail buffered messages 3, 4, and 5
+		case regexp.MustCompile(
+			`^{"level":"info","msg":"Buffered log entry [345]"}$`,
+		).MatchString(req.Request.(*pb.SendLogsRequest_LogEntry).LogEntry.JsonMessage):
+			return true
+
+		default:
+			return false
+		}
+	})).Return(errors.New("send error")).Once()
+
+	// Flush the buffer
+	suite.grpcSyncer.flush()
+
+	// Assert that lostLogEntriesCount is reset
+	suite.Equal(0, suite.grpcSyncer.lostLogEntriesCount, "lostLogEntriesCount should be reset after successfully sending 'Lost logs' message")
+	suite.Len(suite.grpcSyncer.buffer, 3, "Buffer should still contain 3 messages after flushing 2 messages")
+	suite.ErrorContains(suite.grpcSyncer.lostLogEntriesErr, "send error", "lostLogEntriesErr should contain the last Send error")
+}
+
+func (suite *BufferedGrpcWriteSyncerTestSuite) TestFlushSendLostLogsFailed() {
+	// Simulate buffer overflow
+	suite.grpcSyncer.lostLogEntriesCount = 1234
+	suite.grpcSyncer.lostLogEntriesErr = errors.New("some buffer overflow error")
+	suite.grpcSyncer.buffer = append(
+		suite.grpcSyncer.buffer,
+		`{"level":"info","msg":"Buffered log entry 1"}`,
+		`{"level":"info","msg":"Buffered log entry 2"}`,
+		`{"level":"info","msg":"Buffered log entry 3"}`,
+		`{"level":"info","msg":"Buffered log entry 4"}`,
+		`{"level":"info","msg":"Buffered log entry 5"}`,
+	)
+
+	suite.mockClient.On("Send", mock.MatchedBy(func(req *pb.SendLogsRequest) bool {
+		switch {
+		// Fail the 'Lost logs' message
+		case regexp.MustCompile(
+			`^{"level":"error","ts":[^,]*,"msg":"Lost logs due to buffer overflow","error":"some buffer overflow error","lost_log_entries":1234}$`,
+		).MatchString(req.Request.(*pb.SendLogsRequest_LogEntry).LogEntry.JsonMessage):
+			return true
+
+		default:
+			return false
+		}
+	})).Return(errors.New("send error")).Once()
+
+	// Flush the buffer
+	suite.grpcSyncer.flush()
+
+	// Assert that lostLogEntriesCount is reset
+	suite.Equal(1234, suite.grpcSyncer.lostLogEntriesCount, "lostLogEntriesCount should not be reset after failing to send 'Lost logs' message")
+	suite.Len(suite.grpcSyncer.buffer, 5, "Buffer should still contain 3 messages after flushing 2 messages")
+	suite.ErrorContains(suite.grpcSyncer.lostLogEntriesErr, "send error", "lostLogEntriesErr should contain the last Send error")
+}
+
+func (suite *BufferedGrpcWriteSyncerTestSuite) TestLostLogEntriesCountIncrementOnBufferOverflow() {
+	// Fill the buffer to its capacity
+	for i := 0; i < logMaxBufferSize; i++ {
+		suite.grpcSyncer.buffer = append(suite.grpcSyncer.buffer, fmt.Sprintf(`{"level":"info","msg":"Buffered log entry %d"}`, i+1))
+	}
+
+	// Attempt to write a new log entry, causing overflow
+	suite.mockClient.On("Send", mock.Anything).Return(errors.New("send error")).Times(logMaxBufferSize + 1)
+	suite.grpcSyncer.write(`{"level":"info","msg":"Overflow log entry"}`)
+
+	// Assert that lostLogEntriesCount is incremented
+	suite.Equal(1, suite.grpcSyncer.lostLogEntriesCount, "lostLogEntriesCount should be incremented on buffer overflow")
+	suite.Equal(logMaxBufferSize, len(suite.grpcSyncer.buffer), "Buffer should remain at max capacity")
+	suite.ErrorContains(suite.grpcSyncer.lostLogEntriesErr, "send error", "lostLogEntriesErr should contain the last Send error")
 }


### PR DESCRIPTION
Preserve remaining buffered messages during flush if any message failed to be sent.
Properly count dropped messages under all failure conditions.
Add unit tests for message buffering logic.