### PR TITLE
changes to buildResourceApiGroupMap

### DIFF
--- a/internal/controller/streams.go
+++ b/internal/controller/streams.go
@@ -179,6 +179,11 @@ func (sm *streamManager) buildResourceApiGroupMap(resources []string, clientset 
 
 	// Iterate over all API groups and versions
 	for _, group := range apiGroups.Groups {
+		// Skip metrics API group
+		if group.Name == "metrics.k8s.io" {
+			continue
+		}
+
 		for _, version := range group.Versions {
 			resourceList, err := discoveryClient.ServerResourcesForGroupVersion(version.GroupVersion)
 			if err != nil {


### PR DESCRIPTION
Excluded metrics.k8s.io API group in buildResourceApiGroupMap as the service account has no permissions to read this.  