### PR TITLE
Generate the CycloneDX SBOM for every release

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,8 @@ ARG GCI_VERSION=v0.13.7
 ARG GOLANGCI_VERSION=v2.3.1
 ARG HELM_VERSION=v3.18.5
 ARG KIND_VERSION=v0.29.0
+ARG SBOM_UTILITY=v0.18.1
+ARG SYFT_VERSION=v1.31.0
 
 USER root
 
@@ -40,10 +42,14 @@ USER vscode
 RUN go install github.com/bufbuild/buf/cmd/buf@${BUF_VERSION} \
     && go install github.com/daixiang0/gci@${GCI_VERSION} \
     && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_VERSION} \
-    && go install sigs.k8s.io/kind@${KIND_VERSION}
+    && go install sigs.k8s.io/kind@${KIND_VERSION} \
+    && go install github.com/CycloneDX/sbom-utility@${SBOM_UTILITY} \
+    && go install github.com/anchore/syft/cmd/syft@${SYFT_VERSION}
 
 USER root
 
-RUN /go/bin/buf completion bash > "/etc/bash_completion.d/buf"
+RUN /go/bin/buf completion bash > "/etc/bash_completion.d/buf" \
+    && /go/bin/sbom-utility completion bash > "/etc/bash_completion.d/sbom-utility" \
+    && /go/bin/syft completion bash > "/etc/bash_completion.d/syft"
 
 USER vscode

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -6,7 +6,6 @@ on:
       - "v*"
 
 permissions:
-  attestations: write
   # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
   id-token: write
   packages: write
@@ -21,11 +20,6 @@ jobs:
 
       - name: Check Cosign install
         run: cosign version
-
-      - name: Install CycloneDX SBOM tools
-        run: |
-          go install github.com/anchore/syft/cmd/syft@v1.31.0
-          go install github.com/CycloneDX/sbom-utility@v0.18.1
 
       - name: Checkout code
         uses: actions/checkout@v5
@@ -52,31 +46,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
-      - name: Generate SBOM
-        id: generate-sbom
-        run: |
-          SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true SYFT_FILE_METADATA_SELECTION=owned-by-package syft scan registry:ghcr.io/illumio/cloud-operator:v1.3.1 --scope squashed --exclude '/usr/share/zoneinfo' --exclude '/usr/share/common-licenses' --exclude '/usr/share/base-files' -o cyclonedx-json | json_pp > sbom.cyclonedx.json
-          # Fix the license for Debian's base-files package:
-          sed -e 's/"name : "GPL"/"id" : "GPL-2.0-or-later"/' -i sbom.cyclonedx.json
-
       - name: Sign the images with GitHub OIDC Token
         run: cosign sign --yes ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-
-      - name: Attest SBOM to Docker image
-        uses: actions/attest-sbom@v2
-        with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: "sbom.cyclonedx.json"
-          push-to-registry: true
-
-      - name: Upload SBOM as release asset (on release)
-        if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "./sbom.cyclonedx.json"
-          asset_name: sbom-${{ github.ref_name }}.cyclonedx.json
-          asset_content_type: application/json

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -6,6 +6,7 @@ on:
       - "v*"
 
 permissions:
+  attestations: write
   # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
   id-token: write
   packages: write
@@ -20,6 +21,11 @@ jobs:
 
       - name: Check Cosign install
         run: cosign version
+
+      - name: Install CycloneDX SBOM tools
+        run: |
+          go install github.com/anchore/syft/cmd/syft@v1.31.0
+          go install github.com/CycloneDX/sbom-utility@v0.18.1
 
       - name: Checkout code
         uses: actions/checkout@v5
@@ -46,5 +52,31 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
+      - name: Generate SBOM
+        id: generate-sbom
+        run: |
+          SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true SYFT_FILE_METADATA_SELECTION=owned-by-package syft scan registry:ghcr.io/illumio/cloud-operator:v1.3.1 --scope squashed --exclude '/usr/share/zoneinfo' --exclude '/usr/share/common-licenses' --exclude '/usr/share/base-files' -o cyclonedx-json | json_pp > sbom.cyclonedx.json
+          # Fix the license for Debian's base-files package:
+          sed -e 's/"name : "GPL"/"id" : "GPL-2.0-or-later"/' -i sbom.cyclonedx.json
+
       - name: Sign the images with GitHub OIDC Token
         run: cosign sign --yes ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+
+      - name: Attest SBOM to Docker image
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: "sbom.cyclonedx.json"
+          push-to-registry: true
+
+      - name: Upload SBOM as release asset (on release)
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "./sbom.cyclonedx.json"
+          asset_name: sbom-${{ github.ref_name }}.cyclonedx.json
+          asset_content_type: application/json

--- a/.github/workflows/build_and_release_test_sbom.yml
+++ b/.github/workflows/build_and_release_test_sbom.yml
@@ -1,0 +1,106 @@
+name: Test CycloneDX SBOM Generation
+
+on:
+  push:
+    tags:
+      # Temporarily trigger this workflow only on test* tags instead of v*, for testing
+      - "test*"
+
+permissions:
+  attestations: write
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.9.2
+
+      - name: Check Cosign install
+        run: cosign version
+
+      - name: Install CycloneDX SBOM tools
+        run: |
+          go install github.com/anchore/syft/cmd/syft@v1.31.0
+          go install github.com/CycloneDX/sbom-utility@v0.18.1
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+
+      - name: Generate SBOM
+        id: generate-sbom
+        run: |
+          SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true SYFT_FILE_METADATA_SELECTION=owned-by-package syft scan registry:ghcr.io/illumio/cloud-operator:v1.3.1 --scope squashed --exclude '/usr/share/zoneinfo' --exclude '/usr/share/common-licenses' --exclude '/usr/share/base-files' -o cyclonedx-json | json_pp > sbom.cyclonedx.json
+
+          # Fix the license for Debian's base-files package:
+          sed -e 's/"name : "GPL"/"id" : "GPL-2.0-or-later"/' -i sbom.cyclonedx.json
+
+          # Generate a human-readable Markdown version of the SBOM
+          cat >sbom.md <<EOF
+          # Illumio CloudSecure Cloud Operator SBOM
+
+          Version: ${{ github.ref_name }}
+
+          | Name | Version | Publisher | License(s) |
+          |---|---|---|---|
+          EOF
+          jq -r '[.components[] | select(.licenses != null) | {name:.name,version:.version,publisher:(.publisher // ""),licenses:([.licenses[] | .license.id,.license.name | values | select(test("sha256:") | not)] | unique | join(", "))}] | unique | .[] | ("| " + .name + " | " + .version + " | " + .publisher + " | " + .licenses + " |")' <sbom.cyclonedx.json >>sbom.md
+
+      - name: Sign the images with GitHub OIDC Token
+        run: cosign sign --yes ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+
+      - name: Attest CycloneDX SBOM to Docker image
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: "sbom.cyclonedx.json"
+          push-to-registry: true
+
+      - name: Upload CycloneDX SBOM as release asset
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "./sbom.cyclonedx.json"
+          asset_name: sbom-${{ github.ref_name }}.cyclonedx.json
+          asset_content_type: application/json
+
+      - name: Upload Markdown SBOM as release asset
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "./sbom.md"
+          asset_name: sbom-${{ github.ref_name }}.md
+          asset_content_type: text/markdown

--- a/.github/workflows/build_and_release_test_sbom.yml
+++ b/.github/workflows/build_and_release_test_sbom.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Generate SBOM
         id: generate-sbom
         run: |
-          SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true SYFT_FILE_METADATA_SELECTION=owned-by-package syft scan registry:ghcr.io/illumio/cloud-operator:v1.3.1 --scope squashed --exclude '/usr/share/zoneinfo' --exclude '/usr/share/common-licenses' --exclude '/usr/share/base-files' -o cyclonedx-json | json_pp > sbom.cyclonedx.json
+          SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true SYFT_FILE_METADATA_SELECTION=owned-by-package syft scan registry:ghcr.io/${{ github.repository }}:${{ github.ref_name }} --scope squashed --exclude '/usr/share/zoneinfo' --exclude '/usr/share/common-licenses' --exclude '/usr/share/base-files' -o cyclonedx-json | json_pp > sbom.cyclonedx.json
 
           # Fix the license for Debian's base-files package:
           sed -e 's/"name : "GPL"/"id" : "GPL-2.0-or-later"/' -i sbom.cyclonedx.json
@@ -91,7 +91,7 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: "./sbom.cyclonedx.json"
-          asset_name: sbom-${{ github.ref_name }}.cyclonedx.json
+          asset_name: cloud-operator-sbom-${{ github.ref_name }}.cyclonedx.json
           asset_content_type: application/json
 
       - name: Upload Markdown SBOM as release asset
@@ -102,5 +102,5 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: "./sbom.md"
-          asset_name: sbom-${{ github.ref_name }}.md
+          asset_name: cloud-operator-sbom-${{ github.ref_name }}.md
           asset_content_type: text/markdown


### PR DESCRIPTION
Install Syft and CycloneDX's sbom-utility in devcontainer.
Update the release GitHub Action to generate and upload the SBOM.

Temporarily define the new workflow to only trigger on releases with tags named `test*`.
Will make it the main workflow on `v*` tags later, after this has been merged and tested.