### PR TITLE
Make flow cache configuration configurable via environment variables

### DIFF
--- a/cloud-operator/templates/cloud-operator-deployment.yaml
+++ b/cloud-operator/templates/cloud-operator-deployment.yaml
@@ -104,6 +104,12 @@ spec:
               value: "{{ .Values.env.tokenEndpoint }}"
             - name: VERBOSE_DEBUGGING
               value: "{{ .Values.env.verboseDebugging }}"
+            - name: FLOW_CACHE_ACTIVE_TIMEOUT
+              value: "{{ .Values.env.flowCache.activeTimeout }}"
+            - name: FLOW_CACHE_MAX_SIZE
+              value: "{{ .Values.env.flowCache.maxSize }}"
+            - name: FLOW_CACHE_CHANNEL_BUFFER_SIZE
+              value: "{{ .Values.env.flowCache.channelBufferSize }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/cloud-operator/templates/cloud-operator-deployment.yaml
+++ b/cloud-operator/templates/cloud-operator-deployment.yaml
@@ -60,6 +60,12 @@ spec:
               value: "{{ join " " .Values.cilium.namespaces }}"
             - name: CLUSTER_CREDS_SECRET
               value: "clustercreds"
+            - name: FLOW_CACHE_ACTIVE_TIMEOUT
+              value: "{{ .Values.env.flowCache.activeTimeout }}"
+            - name: FLOW_CACHE_CHANNEL_BUFFER_SIZE
+              value: "{{ .Values.env.flowCache.channelBufferSize }}"
+            - name: FLOW_CACHE_MAX_SIZE
+              value: "{{ .Values.env.flowCache.maxSize }}"
             - name: GRPC_INTERNAL_LOGGING
               value: "{{ .Values.env.grpcInternalLogging }}"
             - name: HTTPS_PROXY
@@ -104,12 +110,6 @@ spec:
               value: "{{ .Values.env.tokenEndpoint }}"
             - name: VERBOSE_DEBUGGING
               value: "{{ .Values.env.verboseDebugging }}"
-            - name: FLOW_CACHE_ACTIVE_TIMEOUT
-              value: "{{ .Values.env.flowCache.activeTimeout }}"
-            - name: FLOW_CACHE_MAX_SIZE
-              value: "{{ .Values.env.flowCache.maxSize }}"
-            - name: FLOW_CACHE_CHANNEL_BUFFER_SIZE
-              value: "{{ .Values.env.flowCache.channelBufferSize }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/cloud-operator/tests/cloud-operator-deployment_test.yaml
+++ b/cloud-operator/tests/cloud-operator-deployment_test.yaml
@@ -22,102 +22,120 @@ tests:
           value: "clustercreds"
       - equal:
           path: spec.template.spec.containers[0].env[2].name
-          value: "GRPC_INTERNAL_LOGGING"
+          value: "FLOW_CACHE_ACTIVE_TIMEOUT"
       - equal:
           path: spec.template.spec.containers[0].env[2].value
-          value: "false"
+          value: "20s"
       - equal:
           path: spec.template.spec.containers[0].env[3].name
-          value: "HTTPS_PROXY"
+          value: "FLOW_CACHE_CHANNEL_BUFFER_SIZE"
       - equal:
           path: spec.template.spec.containers[0].env[3].value
-          value: ""
+          value: "100"
       - equal:
           path: spec.template.spec.containers[0].env[4].name
-          value: "IPFIX_COLLECTOR_PORT"
+          value: "FLOW_CACHE_MAX_SIZE"
       - equal:
           path: spec.template.spec.containers[0].env[4].value
-          value: "4739"
+          value: "1000"
       - equal:
           path: spec.template.spec.containers[0].env[5].name
-          value: "ONBOARDING_CLIENT_ID"
+          value: "GRPC_INTERNAL_LOGGING"
+      - equal:
+          path: spec.template.spec.containers[0].env[5].value
+          value: "false"
       - equal:
           path: spec.template.spec.containers[0].env[6].name
-          value: "ONBOARDING_CLIENT_SECRET"
+          value: "HTTPS_PROXY"
+      - equal:
+          path: spec.template.spec.containers[0].env[6].value
+          value: ""
       - equal:
           path: spec.template.spec.containers[0].env[7].name
-          value: "ONBOARDING_ENDPOINT"
+          value: "IPFIX_COLLECTOR_PORT"
       - equal:
           path: spec.template.spec.containers[0].env[7].value
-          value: "https://cloud.illum.io/api/v1/k8s_cluster/onboard"
+          value: "4739"
       - equal:
           path: spec.template.spec.containers[0].env[8].name
-          value: "OVNK_NAMESPACE"
-      - equal:
-          path: spec.template.spec.containers[0].env[8].value
-          value: "openshift-ovn-kubernetes"
+          value: "ONBOARDING_CLIENT_ID"
       - equal:
           path: spec.template.spec.containers[0].env[9].name
-          value: "POD_NAMESPACE"
+          value: "ONBOARDING_CLIENT_SECRET"
       - equal:
           path: spec.template.spec.containers[0].env[10].name
-          value: "STATS_LOG_PERIOD"
+          value: "ONBOARDING_ENDPOINT"
       - equal:
           path: spec.template.spec.containers[0].env[10].value
-          value: "30m"
+          value: "https://cloud.illum.io/api/v1/k8s_cluster/onboard"
       - equal:
           path: spec.template.spec.containers[0].env[11].name
-          value: "STREAM_KEEPALIVE_PERIOD_CONFIGURATION"
+          value: "OVNK_NAMESPACE"
       - equal:
           path: spec.template.spec.containers[0].env[11].value
-          value: "10s"
+          value: "openshift-ovn-kubernetes"
       - equal:
           path: spec.template.spec.containers[0].env[12].name
-          value: "STREAM_KEEPALIVE_PERIOD_KUBERNETES_NETWORK_FLOWS"
-      - equal:
-          path: spec.template.spec.containers[0].env[12].value
-          value: "10s"
+          value: "POD_NAMESPACE"
       - equal:
           path: spec.template.spec.containers[0].env[13].name
-          value: "STREAM_KEEPALIVE_PERIOD_KUBERNETES_RESOURCES"
+          value: "STATS_LOG_PERIOD"
       - equal:
           path: spec.template.spec.containers[0].env[13].value
-          value: "10s"
+          value: "30m"
       - equal:
           path: spec.template.spec.containers[0].env[14].name
-          value: "STREAM_KEEPALIVE_PERIOD_LOGS"
+          value: "STREAM_KEEPALIVE_PERIOD_CONFIGURATION"
       - equal:
           path: spec.template.spec.containers[0].env[14].value
           value: "10s"
       - equal:
           path: spec.template.spec.containers[0].env[15].name
-          value: "STREAM_SUCCESS_PERIOD_AUTH"
+          value: "STREAM_KEEPALIVE_PERIOD_KUBERNETES_NETWORK_FLOWS"
       - equal:
           path: spec.template.spec.containers[0].env[15].value
-          value: "2h"
+          value: "10s"
       - equal:
           path: spec.template.spec.containers[0].env[16].name
-          value: "STREAM_SUCCESS_PERIOD_CONNECT"
+          value: "STREAM_KEEPALIVE_PERIOD_KUBERNETES_RESOURCES"
       - equal:
           path: spec.template.spec.containers[0].env[16].value
-          value: "1h"
+          value: "10s"
       - equal:
           path: spec.template.spec.containers[0].env[17].name
-          value: "TLS_SKIP_VERIFY"
+          value: "STREAM_KEEPALIVE_PERIOD_LOGS"
       - equal:
           path: spec.template.spec.containers[0].env[17].value
-          value: "true"
+          value: "10s"
       - equal:
           path: spec.template.spec.containers[0].env[18].name
-          value: "TOKEN_ENDPOINT"
+          value: "STREAM_SUCCESS_PERIOD_AUTH"
       - equal:
           path: spec.template.spec.containers[0].env[18].value
-          value: "https://cloud.illum.io/api/v1/k8s_cluster/authenticate"
+          value: "2h"
       - equal:
           path: spec.template.spec.containers[0].env[19].name
-          value: "VERBOSE_DEBUGGING"
+          value: "STREAM_SUCCESS_PERIOD_CONNECT"
       - equal:
           path: spec.template.spec.containers[0].env[19].value
+          value: "1h"
+      - equal:
+          path: spec.template.spec.containers[0].env[20].name
+          value: "TLS_SKIP_VERIFY"
+      - equal:
+          path: spec.template.spec.containers[0].env[20].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[21].name
+          value: "TOKEN_ENDPOINT"
+      - equal:
+          path: spec.template.spec.containers[0].env[21].value
+          value: "https://cloud.illum.io/api/v1/k8s_cluster/authenticate"
+      - equal:
+          path: spec.template.spec.containers[0].env[22].name
+          value: "VERBOSE_DEBUGGING"
+      - equal:
+          path: spec.template.spec.containers[0].env[22].value
           value: "false"
 
   # Test for replicaCount value

--- a/cloud-operator/values.schema.json
+++ b/cloud-operator/values.schema.json
@@ -39,6 +39,20 @@
         "env": {
             "type": "object",
             "properties": {
+                "flowCache": {
+                    "type": "object",
+                    "properties": {
+                        "activeTimeout": {
+                            "type": "string"
+                        },
+                        "channelBufferSize": {
+                            "type": "integer"
+                        },
+                        "maxSize": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "grpcInternalLogging": {
                     "type": "boolean"
                 },

--- a/cloud-operator/values.yaml
+++ b/cloud-operator/values.yaml
@@ -103,10 +103,10 @@ env:
   flowCache:
     # Duration a flow stays in cache before being evicted and sent.
     activeTimeout: "20s"
-    # Maximum number of flows to hold in cache.
-    maxSize: 1000
     # Buffer size for the outbound flow channel.
     channelBufferSize: 100
+    # Maximum number of flows to hold in cache.
+    maxSize: 1000
 
   # If true, enables GRPC internal logging (connection states, TLS handshakes, transport events).
   # These logs appear at DEBUG level, so they only show when log level is DEBUG.

--- a/cloud-operator/values.yaml
+++ b/cloud-operator/values.yaml
@@ -99,6 +99,15 @@ falco:
         priority: WARNING
 
 env:
+  # Flow cache settings for network flow aggregation before sending to CloudSecure.
+  flowCache:
+    # Duration a flow stays in cache before being evicted and sent.
+    activeTimeout: "20s"
+    # Maximum number of flows to hold in cache.
+    maxSize: 1000
+    # Buffer size for the outbound flow channel.
+    channelBufferSize: 100
+
   # If true, enables GRPC internal logging (connection states, TLS handshakes, transport events).
   # These logs appear at DEBUG level, so they only show when log level is DEBUG.
   grpcInternalLogging: false

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -100,6 +100,10 @@ func main() {
 	// Bind specific environment variables to keys
 	bindEnv(logger, "cilium_namespaces", "CILIUM_NAMESPACES")
 	bindEnv(logger, "cluster_creds", "CLUSTER_CREDS_SECRET")
+	bindEnv(logger, "flow_cache_active_timeout", "FLOW_CACHE_ACTIVE_TIMEOUT")
+	bindEnv(logger, "flow_cache_channel_buffer_size", "FLOW_CACHE_CHANNEL_BUFFER_SIZE")
+	bindEnv(logger, "flow_cache_max_size", "FLOW_CACHE_MAX_SIZE")
+	bindEnv(logger, "grpc_internal_logging", "GRPC_INTERNAL_LOGGING")
 	bindEnv(logger, "https_proxy", "HTTPS_PROXY")
 	bindEnv(logger, "ipfix_collector_port", "IPFIX_COLLECTOR_PORT")
 	bindEnv(logger, "onboarding_client_id", "ONBOARDING_CLIENT_ID")
@@ -117,14 +121,14 @@ func main() {
 	bindEnv(logger, "tls_skip_verify", "TLS_SKIP_VERIFY")
 	bindEnv(logger, "token_endpoint", "TOKEN_ENDPOINT")
 	bindEnv(logger, "verbose_debugging", "VERBOSE_DEBUGGING")
-	bindEnv(logger, "grpc_internal_logging", "GRPC_INTERNAL_LOGGING")
-	bindEnv(logger, "flow_cache_active_timeout", "FLOW_CACHE_ACTIVE_TIMEOUT")
-	bindEnv(logger, "flow_cache_max_size", "FLOW_CACHE_MAX_SIZE")
-	bindEnv(logger, "flow_cache_channel_buffer_size", "FLOW_CACHE_CHANNEL_BUFFER_SIZE")
 
 	// Set default values
 	viper.SetDefault("cilium_namespaces", []string{"kube-system", "gke-managed-dpv2-observability"})
 	viper.SetDefault("cluster_creds", "clustercreds")
+	viper.SetDefault("flow_cache_active_timeout", defaultFlowCacheActiveTimeout)
+	viper.SetDefault("flow_cache_channel_buffer_size", defaultFlowCacheChannelBuffSize)
+	viper.SetDefault("flow_cache_max_size", defaultFlowCacheMaxSize)
+	viper.SetDefault("grpc_internal_logging", false)
 	viper.SetDefault("https_proxy", "")
 	viper.SetDefault("ipfix_collector_port", "4739")
 	viper.SetDefault("onboarding_endpoint", "https://dev.cloud.ilabs.io/api/v1/k8s_cluster/onboard")
@@ -140,10 +144,6 @@ func main() {
 	viper.SetDefault("tls_skip_verify", false)
 	viper.SetDefault("token_endpoint", "https://dev.cloud.ilabs.io/api/v1/k8s_cluster/authenticate")
 	viper.SetDefault("verbose_debugging", false)
-	viper.SetDefault("grpc_internal_logging", false)
-	viper.SetDefault("flow_cache_active_timeout", defaultFlowCacheActiveTimeout)
-	viper.SetDefault("flow_cache_max_size", defaultFlowCacheMaxSize)
-	viper.SetDefault("flow_cache_channel_buffer_size", defaultFlowCacheChannelBuffSize)
 
 	if viper.GetBool("grpc_internal_logging") {
 		logging.SetupGRPCInternalLogging(logger)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,6 +53,10 @@ const (
 
 	defaultStreamSuccessPeriodAuth    = "2h"
 	defaultStreamSuccessPeriodConnect = "1h"
+
+	defaultFlowCacheActiveTimeout   = "20s"
+	defaultFlowCacheMaxSize         = 1000
+	defaultFlowCacheChannelBuffSize = 100
 )
 
 // newHealthHandler returns an HTTP HandlerFunc that checks the health of the
@@ -114,6 +118,9 @@ func main() {
 	bindEnv(logger, "token_endpoint", "TOKEN_ENDPOINT")
 	bindEnv(logger, "verbose_debugging", "VERBOSE_DEBUGGING")
 	bindEnv(logger, "grpc_internal_logging", "GRPC_INTERNAL_LOGGING")
+	bindEnv(logger, "flow_cache_active_timeout", "FLOW_CACHE_ACTIVE_TIMEOUT")
+	bindEnv(logger, "flow_cache_max_size", "FLOW_CACHE_MAX_SIZE")
+	bindEnv(logger, "flow_cache_channel_buffer_size", "FLOW_CACHE_CHANNEL_BUFFER_SIZE")
 
 	// Set default values
 	viper.SetDefault("cilium_namespaces", []string{"kube-system", "gke-managed-dpv2-observability"})
@@ -134,6 +141,9 @@ func main() {
 	viper.SetDefault("token_endpoint", "https://dev.cloud.ilabs.io/api/v1/k8s_cluster/authenticate")
 	viper.SetDefault("verbose_debugging", false)
 	viper.SetDefault("grpc_internal_logging", false)
+	viper.SetDefault("flow_cache_active_timeout", defaultFlowCacheActiveTimeout)
+	viper.SetDefault("flow_cache_max_size", defaultFlowCacheMaxSize)
+	viper.SetDefault("flow_cache_channel_buffer_size", defaultFlowCacheChannelBuffSize)
 
 	if viper.GetBool("grpc_internal_logging") {
 		logging.SetupGRPCInternalLogging(logger)
@@ -203,9 +213,9 @@ func main() {
 	// Create shared components
 	stats := stream.NewStats()
 	flowCache := cache.NewFlowCache(
-		cache.ActiveTimeout,
-		cache.MaxSize,
-		make(chan pb.Flow, cache.ChannelBufferSize),
+		viper.GetDuration("flow_cache_active_timeout"),
+		viper.GetInt("flow_cache_max_size"),
+		make(chan pb.Flow, viper.GetInt("flow_cache_channel_buffer_size")),
 	)
 
 	// Create TlsAuthProps once - persists DisableTLS/DisableALPN flags across reconnections

--- a/internal/controller/stream/flows/cache/cache.go
+++ b/internal/controller/stream/flows/cache/cache.go
@@ -124,6 +124,7 @@ func (c *FlowCache) evictExpiredFlows(ctx context.Context, logger *zap.Logger) {
 
 		c.queue.Remove(frontElem)
 		delete(c.cache, flow.Key())
+
 		evictedCount++
 
 		select {

--- a/internal/controller/stream/flows/cache/cache.go
+++ b/internal/controller/stream/flows/cache/cache.go
@@ -13,16 +13,6 @@ import (
 	pb "github.com/illumio/cloud-operator/api/illumio/cloud/k8sclustersync/v1"
 )
 
-// Flow Cache Configuration.
-const (
-	// ActiveTimeout is the timeout for active flows in the cache.
-	ActiveTimeout = 20 * time.Second
-	// MaxSize is the maximum number of flows to cache.
-	MaxSize = 1000
-	// ChannelBufferSize is the buffer size for flow channels.
-	ChannelBufferSize = 100
-)
-
 // FlowCache caches flows to be exported.
 // Evicts flows from the cache for:
 // - lack of resources: cache has reached maxFlows capacity
@@ -76,6 +66,11 @@ func (c *FlowCache) Run(ctx context.Context, logger *zap.Logger) error {
 	timer := time.NewTimer(c.activeTimeout)
 	defer timer.Stop()
 
+	logger.Debug("Flow cache started",
+		zap.Duration("active_timeout", c.activeTimeout),
+		zap.Int("max_size", c.maxFlows),
+	)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -113,6 +108,7 @@ func (c *FlowCache) Run(ctx context.Context, logger *zap.Logger) error {
 func (c *FlowCache) evictExpiredFlows(ctx context.Context, logger *zap.Logger) {
 	now := time.Now().UTC()
 	cutoff := now.Add(-c.activeTimeout)
+	evictedCount := 0
 
 	for c.queue.Len() > 0 {
 		frontElem := c.queue.Front()
@@ -128,12 +124,20 @@ func (c *FlowCache) evictExpiredFlows(ctx context.Context, logger *zap.Logger) {
 
 		c.queue.Remove(frontElem)
 		delete(c.cache, flow.Key())
+		evictedCount++
 
 		select {
 		case <-ctx.Done():
 			return
 		case c.OutFlows <- flow:
 		}
+	}
+
+	if evictedCount > 0 {
+		logger.Debug("Evicted expired flows",
+			zap.Int("evicted_count", evictedCount),
+			zap.Int("cache_size", len(c.cache)),
+		)
 	}
 }
 
@@ -161,6 +165,11 @@ func (c *FlowCache) evictOldestFlow(ctx context.Context, logger *zap.Logger) err
 	}
 
 	delete(c.cache, flow.Key())
+
+	logger.Debug("Evicted oldest flow due to capacity",
+		zap.Int("cache_size", len(c.cache)),
+		zap.Int("max_size", c.maxFlows),
+	)
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Add environment variables to configure flow cache behavior:
- FLOW_CACHE_ACTIVE_TIMEOUT: timeout before flows are evicted (default: 20s)
- FLOW_CACHE_MAX_SIZE: maximum flows in cache (default: 1000)
- FLOW_CACHE_CHANNEL_BUFFER_SIZE: output channel buffer size (default: 100)

Add debug logging for flow cache operations to help with debugging.