### PR TITLE
Set SO_REUSEADDR on the Falco webhook server port

### DIFF
--- a/internal/controller/stream/flows/falco/server.go
+++ b/internal/controller/stream/flows/falco/server.go
@@ -40,7 +40,14 @@ func StartServer(ctx context.Context, logger *zap.Logger, falcoEventChan chan st
 	go func() {
 		defer close(falcoEventChan)
 
-		var listenerConfig net.ListenConfig
+		listenerConfig := net.ListenConfig{
+			Control: func(network, address string, c syscall.RawConn) error {
+				return c.Control(func(fd uintptr) {
+					// SO_REUSEADDR allows immediate reusing the port after it has been closed.
+					unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+				})
+			},
+		}
 
 		listener, err := listenerConfig.Listen(ctx, "tcp", FalcoPort)
 		if err != nil {

--- a/internal/controller/stream/flows/falco/server.go
+++ b/internal/controller/stream/flows/falco/server.go
@@ -46,7 +46,7 @@ func StartServer(ctx context.Context, logger *zap.Logger, falcoEventChan chan st
 			Control: func(network, address string, c syscall.RawConn) error {
 				return c.Control(func(fd uintptr) {
 					// SO_REUSEADDR allows immediate reusing the port after it has been closed.
-					err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+					err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1) //nolint:gosec
 					if err != nil {
 						logger.Fatal("Failed to set SO_REUSEADDR socket option on Falco server socket", zap.Error(err))
 					}

--- a/internal/controller/stream/flows/falco/server.go
+++ b/internal/controller/stream/flows/falco/server.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"github.com/illumio/cloud-operator/internal/controller/collector"
 )

--- a/internal/controller/stream/flows/falco/server.go
+++ b/internal/controller/stream/flows/falco/server.go
@@ -46,7 +46,10 @@ func StartServer(ctx context.Context, logger *zap.Logger, falcoEventChan chan st
 			Control: func(network, address string, c syscall.RawConn) error {
 				return c.Control(func(fd uintptr) {
 					// SO_REUSEADDR allows immediate reusing the port after it has been closed.
-					unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+					err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+					if err != nil {
+						logger.Fatal("Failed to set SO_REUSEADDR socket option on Falco server socket", zap.Error(err))
+					}
 				})
 			},
 		}


### PR DESCRIPTION
#376 modified the lifecycle of the Falco webhook HTTP server: it is now restarted, and the TCP socket closed and reopened, whenever a full stream reconnection happens.
Set the `SO_REUSEADDR` option on the socket to allow restarting the server port immediately after closing it.