### PR TITLE
Log Hubble Relay agent-node connectivity periodically

### DIFF
--- a/internal/controller/collector/cilium.go
+++ b/internal/controller/collector/cilium.go
@@ -7,6 +7,7 @@ import (
 	cryptotls "crypto/tls"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/flow"
 	observer "github.com/cilium/cilium/api/v1/observer"
@@ -22,6 +23,10 @@ import (
 type CiliumFlowCollector struct {
 	logger *zap.Logger
 	client observer.ObserverClient
+
+	// relayStatusCheckInterval is how often the peer-health watchdog polls
+	// Hubble Relay's ServerStatus RPC. Defaults to HubbleRelayStatusCheckInterval.
+	relayStatusCheckInterval time.Duration
 }
 
 const (
@@ -29,6 +34,14 @@ const (
 
 	// Constants for fetching the mTLS secret.
 	ciliumHubbleMTLSSecretName string = "hubble-relay-client-certs" //nolint:gosec
+
+	// HubbleRelayStatusCheckInterval is how often the peer-health watchdog polls
+	// Hubble Relay's ServerStatus RPC while a flow stream is active.
+	HubbleRelayStatusCheckInterval = 5 * time.Minute
+
+	// relayStatusRPCTimeout bounds a single ServerStatus RPC so a hung Relay
+	// cannot block the watchdog loop.
+	relayStatusRPCTimeout = 10 * time.Second
 )
 
 // NewCiliumFlowCollector connects to Cilium Hubble Relay, sets up an Observer client,
@@ -96,7 +109,11 @@ func NewCiliumFlowCollector(ctx context.Context, logger *zap.Logger, clientset k
 
 	hubbleClient := observer.NewObserverClient(conn)
 
-	return &CiliumFlowCollector{logger: logger, client: hubbleClient}, nil
+	return &CiliumFlowCollector{
+		logger:                   logger,
+		client:                   hubbleClient,
+		relayStatusCheckInterval: HubbleRelayStatusCheckInterval,
+	}, nil
 }
 
 // convertCiliumIP converts a flow.IP object to a pb.IP object.
@@ -227,6 +244,15 @@ func (fm *CiliumFlowCollector) ExportCiliumFlows(ctx context.Context, flowSink F
 	}
 
 	fm.logger.Info("Started collecting Cilium network flows")
+
+	// Watch Hubble Relay's connectivity to its agent nodes for the lifetime of
+	// this stream. This is observability only: it surfaces the otherwise-silent
+	// case where Relay holds the stream open but delivers no flows because it
+	// cannot reach its agents. The watchdog goroutine exits when ctx is done.
+	watchdogCtx, cancelWatchdog := context.WithCancel(ctx)
+	defer cancelWatchdog()
+
+	go fm.monitorRelayPeerHealth(watchdogCtx)
 
 	defer func() {
 		err = stream.CloseSend()

--- a/internal/controller/collector/cilium.go
+++ b/internal/controller/collector/cilium.go
@@ -252,7 +252,7 @@ func (fm *CiliumFlowCollector) ExportCiliumFlows(ctx context.Context, flowSink F
 	watchdogCtx, cancelWatchdog := context.WithCancel(ctx)
 	defer cancelWatchdog()
 
-	go fm.monitorRelayPeerHealth(watchdogCtx)
+	go fm.monitorHubbleRelayServerStatus(watchdogCtx)
 
 	defer func() {
 		err = stream.CloseSend()

--- a/internal/controller/collector/cilium_test.go
+++ b/internal/controller/collector/cilium_test.go
@@ -510,8 +510,19 @@ func (m *mockObserverClient) GetNamespaces(_ context.Context, _ *observer.GetNam
 	return nil, nil //nolint:nilnil // stub method not used in tests
 }
 
-func (m *mockObserverClient) ServerStatus(_ context.Context, _ *observer.ServerStatusRequest, _ ...grpc.CallOption) (*observer.ServerStatusResponse, error) {
-	return nil, nil //nolint:nilnil // stub method not used in tests
+func (m *mockObserverClient) ServerStatus(ctx context.Context, in *observer.ServerStatusRequest, opts ...grpc.CallOption) (*observer.ServerStatusResponse, error) {
+	// Fall back to a nil stub when no expectation is registered so existing
+	// tests that never poll ServerStatus keep working unchanged.
+	if len(m.ExpectedCalls) == 0 {
+		return nil, nil //nolint:nilnil // stub method not used in these tests
+	}
+
+	args := m.Called(ctx, in, opts)
+	if resp, ok := args.Get(0).(*observer.ServerStatusResponse); ok {
+		return resp, args.Error(1)
+	}
+
+	return nil, args.Error(1)
 }
 
 // mockGetFlowsClient mocks the observer.Observer_GetFlowsClient stream.

--- a/internal/controller/collector/hubble_watchdog.go
+++ b/internal/controller/collector/hubble_watchdog.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Illumio, Inc. All Rights Reserved.
+
+package collector
+
+import (
+	"context"
+	"time"
+
+	observer "github.com/cilium/cilium/api/v1/observer"
+	"go.uber.org/zap"
+)
+
+// monitorRelayPeerHealth polls Hubble Relay's ServerStatus RPC while a flow
+// stream is active and logs how many agent nodes Relay is currently connected
+// to. This surfaces a blind spot that is otherwise invisible to the operator.
+//
+// Relay maintains its own persistent connections to the per-node Cilium agents
+// (hubble-peer on :4244) and fans their flows in to every consumer. When those
+// relay->agent connections drop and Relay does not reconnect, it keeps the
+// operator's GetFlows stream open while delivering no flows: stream.Recv()
+// blocks with no error and the operator silently logs flows_received: 0.
+//
+// The operator cannot repair the relay->agent hop: that connection is managed
+// entirely by Relay and is shared across all consumers, so reconnecting the
+// operator's own stream would not help. This watchdog is therefore observability
+// only. It logs a Warn whenever Relay reports one or more unavailable nodes
+// (naming them) so operators and support can immediately distinguish "relay
+// healthy but no traffic" from "relay cannot reach its agents", instead of
+// investigating a silent flows_received: 0. It returns when ctx is done.
+func (fm *CiliumFlowCollector) monitorRelayPeerHealth(ctx context.Context) {
+	interval := fm.relayStatusCheckInterval
+	if interval <= 0 {
+		interval = HubbleRelayStatusCheckInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			connected, unavailable, unavailableNodes, ok := fm.queryRelayPeerStatus(ctx)
+			if !ok {
+				// The status RPC itself failed; skip this tick. A genuinely dead
+				// Relay is handled by the flow stream's own error path.
+				continue
+			}
+
+			switch {
+			case unavailable > 0:
+				fm.logger.Warn("Hubble Relay cannot reach some agent nodes; cluster network flows may be incomplete",
+					zap.Uint32("connected_nodes", connected),
+					zap.Uint32("unavailable_nodes", unavailable),
+					zap.Strings("unavailable_node_names", unavailableNodes),
+				)
+			case connected == 0:
+				fm.logger.Warn("Hubble Relay reports zero connected agent nodes; no cluster network flows will be collected until Relay reconnects to its agents",
+					zap.Uint32("connected_nodes", connected),
+				)
+			default:
+				fm.logger.Info("Hubble Relay peer status healthy",
+					zap.Uint32("connected_nodes", connected),
+				)
+			}
+		}
+	}
+}
+
+// queryRelayPeerStatus issues a single, timeout-bounded ServerStatus RPC and
+// returns the connected/unavailable node counts and unavailable node names. ok
+// is false if the status could not be determined.
+func (fm *CiliumFlowCollector) queryRelayPeerStatus(ctx context.Context) (connected, unavailable uint32, unavailableNodes []string, ok bool) {
+	rpcCtx, cancel := context.WithTimeout(ctx, relayStatusRPCTimeout)
+	defer cancel()
+
+	resp, err := fm.client.ServerStatus(rpcCtx, &observer.ServerStatusRequest{})
+	if err != nil {
+		fm.logger.Debug("Failed to query Hubble Relay ServerStatus", zap.Error(err))
+
+		return 0, 0, nil, false
+	}
+
+	return resp.GetNumConnectedNodes().GetValue(),
+		resp.GetNumUnavailableNodes().GetValue(),
+		resp.GetUnavailableNodes(),
+		true
+}

--- a/internal/controller/collector/hubble_watchdog.go
+++ b/internal/controller/collector/hubble_watchdog.go
@@ -4,30 +4,36 @@ package collector
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	observer "github.com/cilium/cilium/api/v1/observer"
 	"go.uber.org/zap"
 )
 
-// monitorRelayPeerHealth polls Hubble Relay's ServerStatus RPC while a flow
-// stream is active and logs how many agent nodes Relay is currently connected
-// to. This surfaces a blind spot that is otherwise invisible to the operator.
+// maxLoggedUnavailableNodes bounds how many unavailable node names are included
+// in a log entry. Hubble Relay can report hundreds of unavailable nodes, so the
+// list is sorted and truncated to keep log lines readable.
+const maxLoggedUnavailableNodes = 10
+
+// monitorHubbleRelayServerStatus polls Hubble Relay's ServerStatus RPC while a
+// flow stream is active and logs how many agent nodes Relay is currently
+// connected to. This surfaces a blind spot that is otherwise invisible to the
+// operator.
 //
 // Relay maintains its own persistent connections to the per-node Cilium agents
 // (hubble-peer on :4244) and fans their flows in to every consumer. When those
 // relay->agent connections drop and Relay does not reconnect, it keeps the
 // operator's GetFlows stream open while delivering no flows: stream.Recv()
-// blocks with no error and the operator silently logs flows_received: 0.
+// blocks with no error and the operator silently reports zero flows received.
 //
 // The operator cannot repair the relay->agent hop: that connection is managed
 // entirely by Relay and is shared across all consumers, so reconnecting the
 // operator's own stream would not help. This watchdog is therefore observability
-// only. It logs a Warn whenever Relay reports one or more unavailable nodes
-// (naming them) so operators and support can immediately distinguish "relay
-// healthy but no traffic" from "relay cannot reach its agents", instead of
-// investigating a silent flows_received: 0. It returns when ctx is done.
-func (fm *CiliumFlowCollector) monitorRelayPeerHealth(ctx context.Context) {
+// only. Each tick logs a single Info line with the server status counts (so the
+// stats can be filtered over time with one message), plus a Warn line when Relay
+// cannot reach some or all of its agent nodes. It returns when ctx is done.
+func (fm *CiliumFlowCollector) monitorHubbleRelayServerStatus(ctx context.Context) {
 	interval := fm.relayStatusCheckInterval
 	if interval <= 0 {
 		interval = HubbleRelayStatusCheckInterval
@@ -41,43 +47,61 @@ func (fm *CiliumFlowCollector) monitorRelayPeerHealth(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			connected, unavailable, unavailableNodes, ok := fm.queryRelayPeerStatus(ctx)
+			numConnectedNodes, numUnavailableNodes, unavailableNodes, ok := fm.queryHubbleRelayServerStatus(ctx)
 			if !ok {
 				// The status RPC itself failed; skip this tick. A genuinely dead
 				// Relay is handled by the flow stream's own error path.
 				continue
 			}
 
-			switch {
-			case unavailable > 0:
-				fm.logger.Warn("Hubble Relay cannot reach some agent nodes; cluster network flows may be incomplete",
-					zap.Uint32("connected_nodes", connected),
-					zap.Uint32("unavailable_nodes", unavailable),
-					zap.Strings("unavailable_node_names", unavailableNodes),
-				)
-			case connected == 0:
-				fm.logger.Warn("Hubble Relay reports zero connected agent nodes; no cluster network flows will be collected until Relay reconnects to its agents",
-					zap.Uint32("connected_nodes", connected),
-				)
-			default:
-				fm.logger.Info("Hubble Relay peer status healthy",
-					zap.Uint32("connected_nodes", connected),
+			loggedNodes := boundUnavailableNodes(unavailableNodes)
+
+			fm.logger.Info("Hubble Relay server status",
+				zap.Uint32("numConnectedNodes", numConnectedNodes),
+				zap.Uint32("numUnavailableNodes", numUnavailableNodes),
+				zap.Strings("unavailableNodes", loggedNodes),
+			)
+
+			if numUnavailableNodes > 0 || numConnectedNodes == 0 {
+				fm.logger.Warn("Hubble Relay cannot reach some or all of its agent nodes; cluster network flows may be incomplete or missing",
+					zap.Uint32("numConnectedNodes", numConnectedNodes),
+					zap.Uint32("numUnavailableNodes", numUnavailableNodes),
+					zap.Strings("unavailableNodes", loggedNodes),
 				)
 			}
 		}
 	}
 }
 
-// queryRelayPeerStatus issues a single, timeout-bounded ServerStatus RPC and
-// returns the connected/unavailable node counts and unavailable node names. ok
-// is false if the status could not be determined.
-func (fm *CiliumFlowCollector) queryRelayPeerStatus(ctx context.Context) (connected, unavailable uint32, unavailableNodes []string, ok bool) {
+// boundUnavailableNodes returns a sorted copy of nodes truncated to
+// maxLoggedUnavailableNodes entries so log lines stay readable when Relay
+// reports a large number of unavailable nodes.
+func boundUnavailableNodes(nodes []string) []string {
+	if len(nodes) == 0 {
+		return nodes
+	}
+
+	sorted := make([]string, len(nodes))
+	copy(sorted, nodes)
+	sort.Strings(sorted)
+
+	if len(sorted) > maxLoggedUnavailableNodes {
+		return sorted[:maxLoggedUnavailableNodes]
+	}
+
+	return sorted
+}
+
+// queryHubbleRelayServerStatus issues a single, timeout-bounded ServerStatus RPC
+// and returns the connected/unavailable node counts and unavailable node names.
+// ok is false if the status could not be determined.
+func (fm *CiliumFlowCollector) queryHubbleRelayServerStatus(ctx context.Context) (numConnectedNodes, numUnavailableNodes uint32, unavailableNodes []string, ok bool) {
 	rpcCtx, cancel := context.WithTimeout(ctx, relayStatusRPCTimeout)
 	defer cancel()
 
 	resp, err := fm.client.ServerStatus(rpcCtx, &observer.ServerStatusRequest{})
 	if err != nil {
-		fm.logger.Debug("Failed to query Hubble Relay ServerStatus", zap.Error(err))
+		fm.logger.Warn("Failed to query Hubble Relay ServerStatus", zap.Error(err))
 
 		return 0, 0, nil, false
 	}

--- a/internal/controller/collector/hubble_watchdog_test.go
+++ b/internal/controller/collector/hubble_watchdog_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Illumio, Inc. All Rights Reserved.
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	observer "github.com/cilium/cilium/api/v1/observer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// serverStatus builds a ServerStatusResponse with the given connected and
+// unavailable node counts.
+func serverStatus(connected, unavailable uint32, unavailableNodes ...string) *observer.ServerStatusResponse {
+	return &observer.ServerStatusResponse{
+		NumConnectedNodes:   wrapperspb.UInt32(connected),
+		NumUnavailableNodes: wrapperspb.UInt32(unavailable),
+		UnavailableNodes:    unavailableNodes,
+	}
+}
+
+// TestMonitorRelayPeerHealth_WarnsOnUnavailableNodes verifies that the watchdog
+// logs a Warn naming the unavailable peers when Relay reports some agents it
+// cannot reach.
+func TestMonitorRelayPeerHealth_WarnsOnUnavailableNodes(t *testing.T) {
+	core, logs := zapobserver.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	mockClient := &mockObserverClient{}
+	mockClient.On("ServerStatus", mock.Anything, mock.Anything, mock.Anything).
+		Return(serverStatus(6, 2, "node-a", "node-b"), nil)
+
+	fm := &CiliumFlowCollector{
+		logger:                   logger,
+		client:                   mockClient,
+		relayStatusCheckInterval: 5 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go fm.monitorRelayPeerHealth(ctx)
+
+	require.Eventually(t, func() bool {
+		return logs.FilterMessageSnippet("cannot reach some agent nodes").Len() > 0
+	}, time.Second, 5*time.Millisecond, "expected a warning about unavailable nodes")
+
+	entry := logs.FilterMessageSnippet("cannot reach some agent nodes").All()[0]
+	assert.Contains(t, entry.ContextMap()["unavailable_node_names"], "node-a")
+	assert.EqualValues(t, 6, entry.ContextMap()["connected_nodes"])
+}
+
+// TestMonitorRelayPeerHealth_WarnsOnZeroConnectedNodes verifies that the
+// watchdog logs a distinct Warn when Relay reports zero connected nodes, which
+// is the silent flows_received: 0 case.
+func TestMonitorRelayPeerHealth_WarnsOnZeroConnectedNodes(t *testing.T) {
+	core, logs := zapobserver.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	mockClient := &mockObserverClient{}
+	mockClient.On("ServerStatus", mock.Anything, mock.Anything, mock.Anything).
+		Return(serverStatus(0, 0), nil)
+
+	fm := &CiliumFlowCollector{
+		logger:                   logger,
+		client:                   mockClient,
+		relayStatusCheckInterval: 5 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go fm.monitorRelayPeerHealth(ctx)
+
+	require.Eventually(t, func() bool {
+		return logs.FilterMessageSnippet("zero connected agent nodes").Len() > 0
+	}, time.Second, 5*time.Millisecond, "expected a warning about zero connected nodes")
+}
+
+// TestMonitorRelayPeerHealth_HealthyLogsInfo verifies that a fully healthy peer
+// status logs at Info level and does not emit a warning.
+func TestMonitorRelayPeerHealth_HealthyLogsInfo(t *testing.T) {
+	core, logs := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(core)
+
+	mockClient := &mockObserverClient{}
+	mockClient.On("ServerStatus", mock.Anything, mock.Anything, mock.Anything).
+		Return(serverStatus(8, 0), nil)
+
+	fm := &CiliumFlowCollector{
+		logger:                   logger,
+		client:                   mockClient,
+		relayStatusCheckInterval: 5 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go fm.monitorRelayPeerHealth(ctx)
+
+	require.Eventually(t, func() bool {
+		return logs.FilterMessageSnippet("peer status healthy").Len() > 0
+	}, time.Second, 5*time.Millisecond, "expected a healthy status info log")
+
+	assert.Zero(t, logs.FilterLevelExact(zap.WarnLevel).Len(), "healthy status must not warn")
+}
+
+// TestMonitorRelayPeerHealth_StatusRPCErrorSkipsTick verifies that a failing
+// ServerStatus RPC is logged at Debug and does not produce a peer-health
+// warning or info line.
+func TestMonitorRelayPeerHealth_StatusRPCErrorSkipsTick(t *testing.T) {
+	core, logs := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(core)
+
+	mockClient := &mockObserverClient{}
+	mockClient.On("ServerStatus", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, errors.New("relay unreachable"))
+
+	fm := &CiliumFlowCollector{
+		logger:                   logger,
+		client:                   mockClient,
+		relayStatusCheckInterval: 5 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go fm.monitorRelayPeerHealth(ctx)
+
+	// Give the watchdog several poll intervals.
+	time.Sleep(40 * time.Millisecond)
+
+	assert.Zero(t, logs.Len(), "status RPC errors must not emit info/warn peer-health logs")
+}
+
+// TestMonitorRelayPeerHealth_StopsOnContextDone verifies the watchdog returns
+// promptly when its context is cancelled.
+func TestMonitorRelayPeerHealth_StopsOnContextDone(t *testing.T) {
+	logger := zap.NewNop()
+
+	mockClient := &mockObserverClient{}
+	mockClient.On("ServerStatus", mock.Anything, mock.Anything, mock.Anything).
+		Return(serverStatus(8, 0), nil)
+
+	fm := &CiliumFlowCollector{
+		logger:                   logger,
+		client:                   mockClient,
+		relayStatusCheckInterval: 5 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan struct{})
+
+	go func() {
+		fm.monitorRelayPeerHealth(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not return after context cancellation")
+	}
+}

--- a/internal/controller/collector/hubble_watchdog_test.go
+++ b/internal/controller/collector/hubble_watchdog_test.go
@@ -5,6 +5,7 @@ package collector
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,6 +18,31 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
+// loggedNodeNames normalizes a zap.Strings log field read back via ContextMap,
+// which reflects slices to []interface{}, into a []string.
+func loggedNodeNames(t *testing.T, v any) []string {
+	t.Helper()
+
+	switch nodes := v.(type) {
+	case []string:
+		return nodes
+	case []any:
+		out := make([]string, 0, len(nodes))
+		for _, n := range nodes {
+			s, ok := n.(string)
+			require.True(t, ok, "node name should be a string")
+
+			out = append(out, s)
+		}
+
+		return out
+	default:
+		t.Fatalf("unexpected type for unavailableNodes: %T", v)
+
+		return nil
+	}
+}
+
 // serverStatus builds a ServerStatusResponse with the given connected and
 // unavailable node counts.
 func serverStatus(connected, unavailable uint32, unavailableNodes ...string) *observer.ServerStatusResponse {
@@ -27,16 +53,16 @@ func serverStatus(connected, unavailable uint32, unavailableNodes ...string) *ob
 	}
 }
 
-// TestMonitorRelayPeerHealth_WarnsOnUnavailableNodes verifies that the watchdog
-// logs a Warn naming the unavailable peers when Relay reports some agents it
-// cannot reach.
-func TestMonitorRelayPeerHealth_WarnsOnUnavailableNodes(t *testing.T) {
-	core, logs := zapobserver.New(zap.WarnLevel)
+// TestMonitorHubbleRelayServerStatus_WarnsOnUnavailableNodes verifies that the
+// watchdog logs both the unconditional Info status line and a Warn (naming the
+// unavailable nodes) when Relay reports agents it cannot reach.
+func TestMonitorHubbleRelayServerStatus_WarnsOnUnavailableNodes(t *testing.T) {
+	core, logs := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(core)
 
 	mockClient := &mockObserverClient{}
 	mockClient.On("ServerStatus", mock.Anything, mock.Anything, mock.Anything).
-		Return(serverStatus(6, 2, "node-a", "node-b"), nil)
+		Return(serverStatus(6, 2, "node-b", "node-a"), nil)
 
 	fm := &CiliumFlowCollector{
 		logger:                   logger,
@@ -47,22 +73,28 @@ func TestMonitorRelayPeerHealth_WarnsOnUnavailableNodes(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	go fm.monitorRelayPeerHealth(ctx)
+	go fm.monitorHubbleRelayServerStatus(ctx)
 
 	require.Eventually(t, func() bool {
-		return logs.FilterMessageSnippet("cannot reach some agent nodes").Len() > 0
+		return logs.FilterMessageSnippet("cannot reach").Len() > 0
 	}, time.Second, 5*time.Millisecond, "expected a warning about unavailable nodes")
 
-	entry := logs.FilterMessageSnippet("cannot reach some agent nodes").All()[0]
-	assert.Contains(t, entry.ContextMap()["unavailable_node_names"], "node-a")
-	assert.EqualValues(t, 6, entry.ContextMap()["connected_nodes"])
+	// The unconditional Info status line is always present.
+	statusEntry := logs.FilterMessage("Hubble Relay server status").All()[0]
+	assert.EqualValues(t, 6, statusEntry.ContextMap()["numConnectedNodes"])
+	assert.EqualValues(t, 2, statusEntry.ContextMap()["numUnavailableNodes"])
+
+	// The Warn line names the unavailable nodes, sorted.
+	warnEntry := logs.FilterMessageSnippet("cannot reach").All()[0]
+	assert.Equal(t, zap.WarnLevel, warnEntry.Level)
+	assert.Equal(t, []string{"node-a", "node-b"}, loggedNodeNames(t, warnEntry.ContextMap()["unavailableNodes"]))
 }
 
-// TestMonitorRelayPeerHealth_WarnsOnZeroConnectedNodes verifies that the
-// watchdog logs a distinct Warn when Relay reports zero connected nodes, which
-// is the silent flows_received: 0 case.
-func TestMonitorRelayPeerHealth_WarnsOnZeroConnectedNodes(t *testing.T) {
-	core, logs := zapobserver.New(zap.WarnLevel)
+// TestMonitorHubbleRelayServerStatus_WarnsOnZeroConnectedNodes verifies that the
+// watchdog warns when Relay reports zero connected nodes, which is the silent
+// zero-flow case, even when no nodes are explicitly listed as unavailable.
+func TestMonitorHubbleRelayServerStatus_WarnsOnZeroConnectedNodes(t *testing.T) {
+	core, logs := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(core)
 
 	mockClient := &mockObserverClient{}
@@ -78,16 +110,16 @@ func TestMonitorRelayPeerHealth_WarnsOnZeroConnectedNodes(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	go fm.monitorRelayPeerHealth(ctx)
+	go fm.monitorHubbleRelayServerStatus(ctx)
 
 	require.Eventually(t, func() bool {
-		return logs.FilterMessageSnippet("zero connected agent nodes").Len() > 0
+		return logs.FilterLevelExact(zap.WarnLevel).Len() > 0
 	}, time.Second, 5*time.Millisecond, "expected a warning about zero connected nodes")
 }
 
-// TestMonitorRelayPeerHealth_HealthyLogsInfo verifies that a fully healthy peer
-// status logs at Info level and does not emit a warning.
-func TestMonitorRelayPeerHealth_HealthyLogsInfo(t *testing.T) {
+// TestMonitorHubbleRelayServerStatus_HealthyLogsInfoOnly verifies that a fully
+// healthy status logs the single Info status line and does not warn.
+func TestMonitorHubbleRelayServerStatus_HealthyLogsInfoOnly(t *testing.T) {
 	core, logs := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(core)
 
@@ -104,19 +136,57 @@ func TestMonitorRelayPeerHealth_HealthyLogsInfo(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	go fm.monitorRelayPeerHealth(ctx)
+	go fm.monitorHubbleRelayServerStatus(ctx)
 
 	require.Eventually(t, func() bool {
-		return logs.FilterMessageSnippet("peer status healthy").Len() > 0
-	}, time.Second, 5*time.Millisecond, "expected a healthy status info log")
+		return logs.FilterMessage("Hubble Relay server status").Len() > 0
+	}, time.Second, 5*time.Millisecond, "expected the info status log")
 
 	assert.Zero(t, logs.FilterLevelExact(zap.WarnLevel).Len(), "healthy status must not warn")
 }
 
-// TestMonitorRelayPeerHealth_StatusRPCErrorSkipsTick verifies that a failing
-// ServerStatus RPC is logged at Debug and does not produce a peer-health
-// warning or info line.
-func TestMonitorRelayPeerHealth_StatusRPCErrorSkipsTick(t *testing.T) {
+// TestMonitorHubbleRelayServerStatus_TruncatesUnavailableNodes verifies that a
+// large unavailable-node list is sorted and truncated in the log entry.
+func TestMonitorHubbleRelayServerStatus_TruncatesUnavailableNodes(t *testing.T) {
+	core, logs := zapobserver.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	// Build more nodes than the log cap, in unsorted order.
+	total := maxLoggedUnavailableNodes + 5
+
+	nodes := make([]string, 0, total)
+	for i := total; i > 0; i-- {
+		nodes = append(nodes, fmt.Sprintf("node-%03d", i))
+	}
+
+	mockClient := &mockObserverClient{}
+	mockClient.On("ServerStatus", mock.Anything, mock.Anything, mock.Anything).
+		Return(serverStatus(1, uint32(total), nodes...), nil)
+
+	fm := &CiliumFlowCollector{
+		logger:                   logger,
+		client:                   mockClient,
+		relayStatusCheckInterval: 5 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go fm.monitorHubbleRelayServerStatus(ctx)
+
+	require.Eventually(t, func() bool {
+		return logs.FilterMessageSnippet("cannot reach").Len() > 0
+	}, time.Second, 5*time.Millisecond, "expected a warning about unavailable nodes")
+
+	warnEntry := logs.FilterMessageSnippet("cannot reach").All()[0]
+	logged := loggedNodeNames(t, warnEntry.ContextMap()["unavailableNodes"])
+	assert.Len(t, logged, maxLoggedUnavailableNodes, "list should be truncated")
+	assert.Equal(t, "node-001", logged[0], "list should be sorted ascending")
+}
+
+// TestMonitorHubbleRelayServerStatus_RPCErrorWarnsAndSkipsTick verifies that a
+// failing ServerStatus RPC is logged at Warn and does not produce a status line.
+func TestMonitorHubbleRelayServerStatus_RPCErrorWarnsAndSkipsTick(t *testing.T) {
 	core, logs := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(core)
 
@@ -133,17 +203,19 @@ func TestMonitorRelayPeerHealth_StatusRPCErrorSkipsTick(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	go fm.monitorRelayPeerHealth(ctx)
+	go fm.monitorHubbleRelayServerStatus(ctx)
 
-	// Give the watchdog several poll intervals.
-	time.Sleep(40 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return logs.FilterMessageSnippet("Failed to query Hubble Relay ServerStatus").Len() > 0
+	}, time.Second, 5*time.Millisecond, "expected a warning about the failed RPC")
 
-	assert.Zero(t, logs.Len(), "status RPC errors must not emit info/warn peer-health logs")
+	assert.Zero(t, logs.FilterMessage("Hubble Relay server status").Len(),
+		"a failed status RPC must not emit a status line")
 }
 
-// TestMonitorRelayPeerHealth_StopsOnContextDone verifies the watchdog returns
-// promptly when its context is cancelled.
-func TestMonitorRelayPeerHealth_StopsOnContextDone(t *testing.T) {
+// TestMonitorHubbleRelayServerStatus_StopsOnContextDone verifies the watchdog
+// returns promptly when its context is cancelled.
+func TestMonitorHubbleRelayServerStatus_StopsOnContextDone(t *testing.T) {
 	logger := zap.NewNop()
 
 	mockClient := &mockObserverClient{}
@@ -161,7 +233,7 @@ func TestMonitorRelayPeerHealth_StopsOnContextDone(t *testing.T) {
 	done := make(chan struct{})
 
 	go func() {
-		fm.monitorRelayPeerHealth(ctx)
+		fm.monitorHubbleRelayServerStatus(ctx)
 		close(done)
 	}()
 


### PR DESCRIPTION
Periodically call Hubble Relay's `Observer.ServerStatus` RPC, which reports its connectivity to the Cilium agents running on all nodes, and log the response along with the flow collection stat logs, to help troubleshoot the cases where the operator reports zero flows with no error.

Sample log output:

```
INFO  Hubble Relay server status   {"numConnectedNodes": 8, "numUnavailableNodes": 0, "unavailableNodes": []}
INFO  Hubble Relay server status   {"numConnectedNodes": 6, "numUnavailableNodes": 2, "unavailableNodes": ["node-a", "node-b"]}
WARN  Hubble Relay cannot reach some or all of its agent nodes; cluster network flows may be incomplete or missing   {"numConnectedNodes": 6, "numUnavailableNodes": 2, "unavailableNodes": ["node-a", "node-b"]}
WARN  Hubble Relay cannot reach some or all of its agent nodes; cluster network flows may be incomplete or missing   {"numConnectedNodes": 0, "numUnavailableNodes": 0, "unavailableNodes": []}
```