### PR TITLE
prevent ReplaceAll deadlock by making snapshot notification non-blocking

### DIFF
--- a/internal/controller/stream/config/cache/cache.go
+++ b/internal/controller/stream/config/cache/cache.go
@@ -111,10 +111,25 @@ func (c *ObjectCache[T]) ReplaceAll(ctx context.Context, objects map[string]T) e
 
 	c.mutex.Unlock()
 
+	// Honor cancellation deterministically before attempting to notify, so a
+	// cancelled snapshot is never reported as successful.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Notify consumers of the full replacement without blocking the caller.
+	// SnapshotReplaced is idempotent ("the whole cache was replaced, reconcile
+	// everything"), so the send is buffered by one and coalescing: if a prior
+	// SnapshotReplaced is still queued because the consumer is not draining yet
+	// (e.g. the reconciler is still waiting on the other cache to become ready,
+	// including across stream reconnects that call ReplaceAll again), dropping
+	// this one is correct and must not block. This fully decouples snapshot
+	// completion from consumer readiness and prevents a startup/reconnect
+	// deadlock that would otherwise wedge the resource stream and trip the
+	// liveness probe.
 	select {
-	case <-ctx.Done():
-		return ctx.Err()
 	case c.resourceChanged <- SnapshotReplaced:
+	default:
 	}
 
 	return nil

--- a/internal/controller/stream/config/cache/cache.go
+++ b/internal/controller/stream/config/cache/cache.go
@@ -95,7 +95,10 @@ func (c *ObjectCache[T]) ResourceChanged() <-chan string {
 // Use this for snapshot ingestion: build a local map, then call ReplaceAll to
 // swap it in. The cache remains consistent until the swap completes.
 // Also marks the cache as ready on first call to indicate cache now has valid data.
-// Sends SnapshotReplaced on the resourceChanged channel to signal a full snapshot replacement.
+// Sends SnapshotReplaced on the resourceChanged channel to signal a full snapshot
+// replacement. The notification is always delivered: if the single-slot buffer is
+// full, ReplaceAll drains the stale value and retries, ensuring SnapshotReplaced
+// is enqueued without blocking indefinitely.
 func (c *ObjectCache[T]) ReplaceAll(ctx context.Context, objects map[string]T) error {
 	c.mutex.Lock()
 
@@ -103,6 +106,9 @@ func (c *ObjectCache[T]) ReplaceAll(ctx context.Context, objects map[string]T) e
 
 	// Mark ready (idempotent - safe to call on reconnect)
 	select {
+	case <-ctx.Done():
+		c.mutex.Unlock()
+		return ctx.Err()
 	case <-c.ready:
 		// Already closed
 	default:
@@ -111,33 +117,24 @@ func (c *ObjectCache[T]) ReplaceAll(ctx context.Context, objects map[string]T) e
 
 	c.mutex.Unlock()
 
-	// Honor cancellation deterministically before attempting to notify, so a
-	// cancelled snapshot is never reported as successful.
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	// Notify consumers of the full replacement without blocking the caller.
-	// SnapshotReplaced supersedes any per-ID signal already queued (it means
-	// "reconcile everything", which subsumes any single object change), so drain
-	// a stale queued value first and then enqueue SnapshotReplaced. On a
-	// single-slot buffer the drain frees the slot, so the send does not block and
-	// the snapshot notification is not lost. This decouples snapshot completion
-	// from consumer readiness and prevents the startup/reconnect deadlock that
-	// would otherwise wedge the resource stream and trip the liveness probe.
-	select {
-	case <-c.resourceChanged:
-		// Drained a stale queued value.
-	default:
-		// Buffer already empty.
-	}
-
-	select {
-	case c.resourceChanged <- SnapshotReplaced:
-	default:
-		// A concurrent Insert/Delete refilled the slot between the drain and this
-		// send. That signal already tells the consumer there is work to do, so
-		// skipping keeps ReplaceAll non-blocking without losing the wakeup.
+	// Notify consumers of the full replacement. SnapshotReplaced supersedes any
+	// per-ID signal already queued (it means "reconcile everything", which
+	// subsumes any single object change). The loop guarantees SnapshotReplaced is
+	// delivered without blocking indefinitely: if the single-slot buffer is full,
+	// it drains the stale value and retries the send. This decouples snapshot
+	// completion from consumer readiness and prevents the startup/reconnect
+	// deadlock that would otherwise wedge the resource stream and trip the
+	// liveness probe.
+Send:
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case c.resourceChanged <- SnapshotReplaced:
+			break Send
+		case <-c.resourceChanged:
+			// Buffer was full; drained a stale queued value, retry the send.
+		}
 	}
 
 	return nil

--- a/internal/controller/stream/config/cache/cache.go
+++ b/internal/controller/stream/config/cache/cache.go
@@ -118,24 +118,26 @@ func (c *ObjectCache[T]) ReplaceAll(ctx context.Context, objects map[string]T) e
 	}
 
 	// Notify consumers of the full replacement without blocking the caller.
-	// SnapshotReplaced is idempotent ("the whole cache was replaced, reconcile
-	// everything"), so the send is buffered by one and coalescing: if a prior
-	// SnapshotReplaced is still queued because the consumer is not draining yet
-	// (e.g. the reconciler is still waiting on the other cache to become ready,
-	// including across stream reconnects that call ReplaceAll again), dropping
-	// this one is correct and must not block. This fully decouples snapshot
-	// completion from consumer readiness and prevents a startup/reconnect
-	// deadlock that would otherwise wedge the resource stream and trip the
-	// liveness probe.
-	//
-	// The ctx.Done() case reports cancellation deterministically when it is
-	// already observable at the notification point, without ever blocking the
-	// caller (the default keeps the send non-blocking).
+	// SnapshotReplaced supersedes any per-ID signal already queued (it means
+	// "reconcile everything", which subsumes any single object change), so drain
+	// a stale queued value first and then enqueue SnapshotReplaced. On a
+	// single-slot buffer the drain frees the slot, so the send does not block and
+	// the snapshot notification is not lost. This decouples snapshot completion
+	// from consumer readiness and prevents the startup/reconnect deadlock that
+	// would otherwise wedge the resource stream and trip the liveness probe.
+	select {
+	case <-c.resourceChanged:
+		// Drained a stale queued value.
+	default:
+		// Buffer already empty.
+	}
+
 	select {
 	case c.resourceChanged <- SnapshotReplaced:
-	case <-ctx.Done():
-		return ctx.Err()
 	default:
+		// A concurrent Insert/Delete refilled the slot between the drain and this
+		// send. That signal already tells the consumer there is work to do, so
+		// skipping keeps ReplaceAll non-blocking without losing the wakeup.
 	}
 
 	return nil

--- a/internal/controller/stream/config/cache/cache.go
+++ b/internal/controller/stream/config/cache/cache.go
@@ -108,6 +108,7 @@ func (c *ObjectCache[T]) ReplaceAll(ctx context.Context, objects map[string]T) e
 	select {
 	case <-ctx.Done():
 		c.mutex.Unlock()
+
 		return ctx.Err()
 	case <-c.ready:
 		// Already closed

--- a/internal/controller/stream/config/cache/cache.go
+++ b/internal/controller/stream/config/cache/cache.go
@@ -127,8 +127,14 @@ func (c *ObjectCache[T]) ReplaceAll(ctx context.Context, objects map[string]T) e
 	// completion from consumer readiness and prevents a startup/reconnect
 	// deadlock that would otherwise wedge the resource stream and trip the
 	// liveness probe.
+	//
+	// The ctx.Done() case reports cancellation deterministically when it is
+	// already observable at the notification point, without ever blocking the
+	// caller (the default keeps the send non-blocking).
 	select {
 	case c.resourceChanged <- SnapshotReplaced:
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 	}
 

--- a/internal/controller/stream/config/cache/cache.go
+++ b/internal/controller/stream/config/cache/cache.go
@@ -27,7 +27,7 @@ import (
 //
 // Block on <-cache.IsReady() to wait for the first snapshot to complete before reading.
 //
-// The cache notifies consumers of changes via an unbuffered resourceChanged channel.
+// The cache notifies consumers of changes via the resourceChanged channel.
 // Insert and Delete send the object ID; ReplaceAll sends SnapshotReplaced to indicate
 // a full snapshot.
 type ObjectCache[T proto.Message] struct {
@@ -41,7 +41,8 @@ type ObjectCache[T proto.Message] struct {
 
 	// resourceChanged carries the ID of every resource modified.
 	// SnapshotReplaced ("*") indicates the entire cache was replaced via a full snapshot.
-	// Unbuffered: the sender blocks until the consumer reads.
+	// Buffered by one so a snapshot notification can be enqueued without blocking
+	// on a consumer that is not yet draining.
 	resourceChanged chan string
 }
 
@@ -52,9 +53,14 @@ const SnapshotReplaced = "*"
 // NewObjectCache creates a new cache instance.
 func NewObjectCache[T proto.Message]() *ObjectCache[T] {
 	return &ObjectCache[T]{
-		objects:         make(map[string]T),
-		ready:           make(chan struct{}),
-		resourceChanged: make(chan string),
+		objects: make(map[string]T),
+		ready:   make(chan struct{}),
+		// Buffered by one so a snapshot swap (ReplaceAll) can enqueue its
+		// SnapshotReplaced notification without blocking on a consumer that is
+		// not yet draining (e.g. the reconciler still waiting on another cache to
+		// become ready). Without the buffer the first snapshot can deadlock the
+		// resource stream, which then fails its liveness probe and crash-loops.
+		resourceChanged: make(chan string, 1),
 	}
 }
 
@@ -77,7 +83,7 @@ func (c *ObjectCache[T]) IsReady() <-chan struct{} {
 	return c.ready
 }
 
-// ResourceChanged returns an unbuffered channel that emits the ID of every resource
+// ResourceChanged returns the channel that emits the ID of every resource
 // modified. SnapshotReplaced ("*") indicates the entire cache was replaced via a full
 // snapshot (ReplaceAll). The cache owns this channel and writes to it on Insert,
 // Delete, and ReplaceAll.

--- a/internal/controller/stream/config/cache/cache_test.go
+++ b/internal/controller/stream/config/cache/cache_test.go
@@ -314,6 +314,7 @@ func TestReplaceAllDoesNotBlockWithoutConsumer(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+
 		for range 3 {
 			err := cache.ReplaceAll(ctx, snapshot)
 			assert.NoError(t, err)

--- a/internal/controller/stream/config/cache/cache_test.go
+++ b/internal/controller/stream/config/cache/cache_test.go
@@ -309,8 +309,8 @@ func TestReplaceAllDoesNotBlockWithoutConsumer(t *testing.T) {
 	}
 
 	// Call ReplaceAll several times with nothing draining ResourceChanged.
-	// Each call must return promptly; the redundant SnapshotReplaced signals
-	// are coalesced (dropped when the buffer is full) rather than blocking.
+	// Each call must return promptly: it drains any stale queued value and
+	// re-enqueues SnapshotReplaced rather than blocking on the full buffer.
 	// Errors are sent back to the main goroutine — *testing.T and testify
 	// helpers are not safe to use concurrently.
 	errCh := make(chan error, 1)
@@ -346,6 +346,40 @@ func TestReplaceAllDoesNotBlockWithoutConsumer(t *testing.T) {
 		assert.Equal(t, SnapshotReplaced, id)
 	default:
 		t.Fatal("expected a coalesced SnapshotReplaced notification to be queued")
+	}
+}
+
+// TestReplaceAllSupersedesQueuedPerIDSignal verifies that when a per-ID
+// notification is already queued and no consumer is draining, ReplaceAll drains
+// it and enqueues SnapshotReplaced instead — a full resync supersedes the stale
+// per-ID signal, and the snapshot notification is never lost or blocked.
+func TestReplaceAllSupersedesQueuedPerIDSignal(t *testing.T) {
+	ctx := context.Background()
+	cache := NewConfiguredObjectCache()
+
+	// Queue a per-ID notification with nothing draining.
+	require.NoError(t, cache.Insert(ctx, "id-1", &pb.ConfiguredKubernetesObjectData{Id: "id-1"}))
+
+	// ReplaceAll must not block and must leave SnapshotReplaced queued.
+	done := make(chan error, 1)
+	go func() {
+		done <- cache.ReplaceAll(ctx, map[string]*pb.ConfiguredKubernetesObjectData{
+			"id-2": {Id: "id-2"},
+		})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReplaceAll blocked when a per-ID signal was already queued")
+	}
+
+	select {
+	case id := <-cache.ResourceChanged():
+		assert.Equal(t, SnapshotReplaced, id, "queued per-ID signal should be superseded by SnapshotReplaced")
+	default:
+		t.Fatal("expected SnapshotReplaced to be queued after ReplaceAll")
 	}
 }
 

--- a/internal/controller/stream/config/cache/cache_test.go
+++ b/internal/controller/stream/config/cache/cache_test.go
@@ -294,6 +294,65 @@ func TestReplaceAll(t *testing.T) {
 	assert.Equal(t, "policy-2", cache.Get("id-2").GetName())
 }
 
+// TestReplaceAllDoesNotBlockWithoutConsumer verifies that ReplaceAll never
+// blocks even when no goroutine is draining ResourceChanged, including when it
+// is called repeatedly before the consumer starts (e.g. across stream
+// reconnects while the reconciler is still waiting on the other cache to become
+// ready). This is the startup/reconnect deadlock the buffered, non-blocking
+// notification is meant to prevent.
+func TestReplaceAllDoesNotBlockWithoutConsumer(t *testing.T) {
+	ctx := context.Background()
+	cache := NewConfiguredObjectCache()
+
+	snapshot := map[string]*pb.ConfiguredKubernetesObjectData{
+		"id-1": {Id: "id-1", Name: "policy-1"},
+	}
+
+	// Call ReplaceAll several times with nothing draining ResourceChanged.
+	// Each call must return promptly; the redundant SnapshotReplaced signals
+	// are coalesced (dropped when the buffer is full) rather than blocking.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 3 {
+			err := cache.ReplaceAll(ctx, snapshot)
+			assert.NoError(t, err)
+		}
+	}()
+
+	select {
+	case <-done:
+		// All calls returned without a consumer — no deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReplaceAll blocked without a consumer draining ResourceChanged")
+	}
+
+	assert.True(t, isReady(cache))
+	assert.Equal(t, 1, cache.Len())
+
+	// A pending notification is still available for the consumer.
+	select {
+	case id := <-cache.ResourceChanged():
+		assert.Equal(t, SnapshotReplaced, id)
+	default:
+		t.Fatal("expected a coalesced SnapshotReplaced notification to be queued")
+	}
+}
+
+// TestReplaceAllCancelledContext verifies that a cancelled context is reported
+// deterministically, rather than being masked by the non-blocking notification.
+func TestReplaceAllCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cache := NewConfiguredObjectCache()
+
+	err := cache.ReplaceAll(ctx, map[string]*pb.ConfiguredKubernetesObjectData{
+		"id-1": {Id: "id-1", Name: "policy-1"},
+	})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestReplaceAllWithEmptyMap(t *testing.T) {
 	ctx := context.Background()
 	cache := NewConfiguredObjectCache()

--- a/internal/controller/stream/config/cache/cache_test.go
+++ b/internal/controller/stream/config/cache/cache_test.go
@@ -311,19 +311,28 @@ func TestReplaceAllDoesNotBlockWithoutConsumer(t *testing.T) {
 	// Call ReplaceAll several times with nothing draining ResourceChanged.
 	// Each call must return promptly; the redundant SnapshotReplaced signals
 	// are coalesced (dropped when the buffer is full) rather than blocking.
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
+	// Errors are sent back to the main goroutine — *testing.T and testify
+	// helpers are not safe to use concurrently.
+	errCh := make(chan error, 1)
 
+	go func() {
 		for range 3 {
-			err := cache.ReplaceAll(ctx, snapshot)
-			assert.NoError(t, err)
+			if err := cache.ReplaceAll(ctx, snapshot); err != nil {
+				errCh <- err
+
+				return
+			}
 		}
+
+		close(errCh)
 	}()
 
 	select {
-	case <-done:
-		// All calls returned without a consumer — no deadlock.
+	case err, ok := <-errCh:
+		if ok {
+			t.Fatalf("ReplaceAll returned an unexpected error: %v", err)
+		}
+		// Channel closed with no error — all calls returned, no deadlock.
 	case <-time.After(5 * time.Second):
 		t.Fatal("ReplaceAll blocked without a consumer draining ResourceChanged")
 	}


### PR DESCRIPTION
ReplaceAll sent SnapshotReplaced on the unbuffered resourceChanged channel with a blocking send, coupling the resource snapshot's completion to a consumer actively draining the channel.

The reconciler is the only consumer, and it does not start draining until both the config and runtime caches are ready. When the config cache has not yet become ready, the reconciler is not draining, so the runtime cache's ReplaceAll blocks indefinitely on the send.

While ReplaceAll is blocked the resource stream never completes its snapshot, the processing flag is never cleared, and the health check starts failing — causing the liveness probe to restart the pod in a loop with no resources ever ingested.

Make sure that sending the SnapshotReplaced notification is never blocking, by first draining all the notifications already in the resourceChanged channel.