### PR TITLE
Add gRPC keepalive to the Hubble Relay connection

### DIFF
--- a/internal/controller/collector/cilium.go
+++ b/internal/controller/collector/cilium.go
@@ -37,7 +37,7 @@ const (
 
 	// HubbleRelayStatusCheckInterval is how often the peer-health watchdog polls
 	// Hubble Relay's ServerStatus RPC while a flow stream is active.
-	HubbleRelayStatusCheckInterval = 5 * time.Minute
+	HubbleRelayStatusCheckInterval = 30 * time.Minute
 
 	// relayStatusRPCTimeout bounds a single ServerStatus RPC so a hung Relay
 	// cannot block the watchdog loop.

--- a/internal/controller/hubble/hubble.go
+++ b/internal/controller/hubble/hubble.go
@@ -9,11 +9,13 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -25,6 +27,17 @@ const (
 	ciliumHubbleRelayExpectedServerName = "ui.hubble-relay.cilium.io"
 	ciliumHubbleRelayServiceName        = "hubble-relay"
 )
+
+// hubbleKeepaliveParams probes the long-lived Relay connection so a dead or
+// half-open operator<->Relay TCP connection is detected instead of leaving the
+// flow stream's Recv() blocked forever. Time is >= Relay's default server-side
+// MinTime (5m) so pings are not rejected with GOAWAY "too_many_pings" on an idle
+// flow stream.
+var hubbleKeepaliveParams = keepalive.ClientParameters{
+	Time:                5 * time.Minute,  // ping after 5m of no activity (== server MinTime)
+	Timeout:             20 * time.Second, // declare the connection dead if no ack within 20s
+	PermitWithoutStream: true,             // keep probing across reconnect gaps
+}
 
 // expectedServerName returns the TLS ServerName to use when connecting to Hubble Relay.
 // For the default Cilium deployment in kube-system, the certificate uses a special DNS name.
@@ -206,6 +219,7 @@ func ConnectToHubbleRelay(ctx context.Context, logger *zap.Logger, hubbleAddress
 		hubbleAddress,
 		grpc.WithTransportCredentials(creds),
 		grpc.WithNoProxy(),
+		grpc.WithKeepaliveParams(hubbleKeepaliveParams),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Cilium Hubble Relay: %w", err)

--- a/internal/controller/hubble/hubble_test.go
+++ b/internal/controller/hubble/hubble_test.go
@@ -510,6 +510,19 @@ func (suite *HubbleSuite) TestConnectToHubbleRelay() {
 	}
 }
 
+// TestHubbleKeepaliveParamsRespectServerMinTime guards the constraint that our
+// client keepalive interval stays >= Hubble Relay's default server-side
+// enforcement MinTime (5m). A smaller Time would earn ping strikes and get the
+// connection closed with GOAWAY "too_many_pings" on an idle flow stream.
+func (suite *HubbleSuite) TestHubbleKeepaliveParamsRespectServerMinTime() {
+	const relayDefaultMinTime = 5 * time.Minute
+
+	suite.GreaterOrEqual(hubbleKeepaliveParams.Time, relayDefaultMinTime,
+		"keepalive Time must be >= Relay's default MinTime to avoid GOAWAY too_many_pings")
+	suite.Positive(hubbleKeepaliveParams.Timeout, "keepalive Timeout must be set so a dead connection is detected")
+	suite.True(hubbleKeepaliveParams.PermitWithoutStream, "keepalive should probe even without an active stream")
+}
+
 func (suite *HubbleSuite) TestGenerateTransportCredentials() {
 	tests := map[string]struct {
 		disableALPN   bool


### PR DESCRIPTION
Client keepalive is off by default in gRPC, so the operator never probes the
  long-lived Relay connection. If the operator↔Relay TCP connection dies or goes
  half-open, the flow stream's `Recv()` blocks forever with no error and flow
  collection silently stops until a pod restart.

  With keepalive, an unacked ping fails the connection, `Recv()` returns an error,
  and the existing backoff/reconnect loop rebuilds it automatically.