### PR TITLE
Bump Golang from 1.26.2 to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.2-trixie AS builder
+FROM golang:1.26.4-trixie AS builder
 ARG VERSION=dev
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/illumio/cloud-operator
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/cilium/cilium v1.19.5


### PR DESCRIPTION
Aligns the operator with the backend (storm) Go version and clears the High-severity Go stdlib CVEs flagged by the security scan.