### PR TITLE
Remove Falco fallback when no supported CNI is detected

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -264,52 +264,60 @@ func main() {
 	})
 
 	// Create factory config with all stream factories
-	factoryConfig := stream.FactoryConfig{
-		Factories: []stream.ManagedFactory{
-			{
-				Factory: &config.Factory{
-					Logger:             logger,
-					VerboseDebugging:   viper.GetBool("verbose_debugging"),
-					BufferedGrpcSyncer: bufferedGrpcSyncer,
-					Stats:              stats,
-					Cache:              configuredObjectCache,
-				},
-				KeepalivePeriod: viper.GetDuration("stream_keepalive_period_configuration"),
+	factories := []stream.ManagedFactory{
+		{
+			Factory: &config.Factory{
+				Logger:             logger,
+				VerboseDebugging:   viper.GetBool("verbose_debugging"),
+				BufferedGrpcSyncer: bufferedGrpcSyncer,
+				Stats:              stats,
+				Cache:              configuredObjectCache,
 			},
-			{
-				Factory: &logs.Factory{
-					Logger:             logger,
-					BufferedGrpcSyncer: bufferedGrpcSyncer,
-				},
-				KeepalivePeriod: viper.GetDuration("stream_keepalive_period_logs"),
-			},
-			{
-				Factory: &resources.Factory{
-					Logger:            logger,
-					Stats:             stats,
-					K8sClient:         k8sClient,
-					FlowCollectorType: flowCollectorType,
-					ClusterName:       envConfig.ClusterName,
-					Cache:             runtimeCache,
-				},
-				KeepalivePeriod: viper.GetDuration("stream_keepalive_period_kubernetes_resources"),
-			},
-			{
-				Factory: &flows.NetworkFlowsFactory{
-					Logger:    logger,
-					FlowCache: flowCache,
-					Stats:     stats,
-				},
-				KeepalivePeriod: viper.GetDuration("stream_keepalive_period_kubernetes_network_flows"),
-			},
-			{
-				Factory: &flows.FlowCollectorStreamFactory{
-					Factory:       flowCollectorFactory,
-					CollectorName: flowCollectorName,
-				},
-				KeepalivePeriod: viper.GetDuration("stream_keepalive_period_kubernetes_network_flows"),
-			},
+			KeepalivePeriod: viper.GetDuration("stream_keepalive_period_configuration"),
 		},
+		{
+			Factory: &logs.Factory{
+				Logger:             logger,
+				BufferedGrpcSyncer: bufferedGrpcSyncer,
+			},
+			KeepalivePeriod: viper.GetDuration("stream_keepalive_period_logs"),
+		},
+		{
+			Factory: &resources.Factory{
+				Logger:            logger,
+				Stats:             stats,
+				K8sClient:         k8sClient,
+				FlowCollectorType: flowCollectorType,
+				ClusterName:       envConfig.ClusterName,
+				Cache:             runtimeCache,
+			},
+			KeepalivePeriod: viper.GetDuration("stream_keepalive_period_kubernetes_resources"),
+		},
+		{
+			Factory: &flows.NetworkFlowsFactory{
+				Logger:    logger,
+				FlowCache: flowCache,
+				Stats:     stats,
+			},
+			KeepalivePeriod: viper.GetDuration("stream_keepalive_period_kubernetes_network_flows"),
+		},
+	}
+
+	// Only register a flow-collector stream when a supported CNI was detected.
+	// A nil factory means no collector is available (flow collection disabled);
+	// in that case we skip the stream entirely rather than falling back.
+	if flowCollectorFactory != nil {
+		factories = append(factories, stream.ManagedFactory{
+			Factory: &flows.FlowCollectorStreamFactory{
+				Factory:       flowCollectorFactory,
+				CollectorName: flowCollectorName,
+			},
+			KeepalivePeriod: viper.GetDuration("stream_keepalive_period_kubernetes_network_flows"),
+		})
+	}
+
+	factoryConfig := stream.FactoryConfig{
+		Factories:      factories,
 		Stats:          stats,
 		SuccessPeriods: envConfig.SuccessPeriods,
 		StatsLogPeriod: envConfig.StatsLogPeriod,

--- a/internal/controller/stream/flows/detect.go
+++ b/internal/controller/stream/flows/detect.go
@@ -13,7 +13,6 @@ import (
 	"github.com/illumio/cloud-operator/internal/controller/stream"
 	"github.com/illumio/cloud-operator/internal/controller/stream/flows/awsvpccni"
 	"github.com/illumio/cloud-operator/internal/controller/stream/flows/cilium"
-	"github.com/illumio/cloud-operator/internal/controller/stream/flows/falco"
 	"github.com/illumio/cloud-operator/internal/controller/stream/flows/ovnk"
 	"github.com/illumio/cloud-operator/internal/pkg/tls"
 )
@@ -148,15 +147,12 @@ func DetectFlowCollector(ctx context.Context, config CollectorConfig) (pb.FlowCo
 		})
 	}
 
-	// Default to Falco
-	config.Logger.Info("Using Falco flow collector")
+	// No supported CNI detected. Flow collection is disabled: the operator does not
+	// fall back to any collector. A nil factory signals the caller not to register a
+	// flow-collector stream. The reported type is FLOW_COLLECTOR_DISABLED so the
+	// backend can surface the lack of flow visibility.
+	config.Logger.Warn("No supported CNI detected; network flow collection is disabled. " +
+		"Configure a supported CNI (Cilium+Hubble, OVN-Kubernetes, or AWS VPC CNI) to enable flow visibility.")
 
-	factory := &falco.Factory{
-		Logger:   config.Logger,
-		FlowSink: flowSink,
-	}
-
-	return pb.FlowCollector_FLOW_COLLECTOR_FALCO, "Falco", collectorFactoryFunc(func(ctx context.Context) (Collector, error) {
-		return factory.NewCollector(ctx)
-	})
+	return pb.FlowCollector_FLOW_COLLECTOR_DISABLED, "None", nil
 }

--- a/internal/controller/stream/flows/detect.go
+++ b/internal/controller/stream/flows/detect.go
@@ -147,12 +147,12 @@ func DetectFlowCollector(ctx context.Context, config CollectorConfig) (pb.FlowCo
 		})
 	}
 
-	// No supported CNI detected. Flow collection is disabled: the operator does not
+	// No supported flow exporter detected. Flow collection is disabled: the operator does not
 	// fall back to any collector. A nil factory signals the caller not to register a
 	// flow-collector stream. The reported type is FLOW_COLLECTOR_DISABLED so the
 	// backend can surface the lack of flow visibility.
-	config.Logger.Warn("No supported CNI detected; network flow collection is disabled. " +
-		"Configure a supported CNI (Cilium+Hubble, OVN-Kubernetes, or AWS VPC CNI) to enable flow visibility.")
+	config.Logger.Warn("No supported flow exporter detected; network flow collection is disabled. " +
+		"Configure a supported CNI plugin (Cilium+Hubble, OVN-Kubernetes, or AWS VPC CNI) to enable flow visibility.")
 
 	return pb.FlowCollector_FLOW_COLLECTOR_DISABLED, "None", nil
 }

--- a/internal/controller/stream/flows/detect_test.go
+++ b/internal/controller/stream/flows/detect_test.go
@@ -9,9 +9,30 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	runtimescheme "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
+	pb "github.com/illumio/cloud-operator/api/illumio/cloud/k8sclustersync/v1"
 	"github.com/illumio/cloud-operator/internal/controller/stream"
 )
+
+// fakeK8sClientGetter implements collector.K8sClientGetter for testing detection.
+type fakeK8sClientGetter struct {
+	clientset kubernetes.Interface
+	dynamic   dynamic.Interface
+	discovery discovery.DiscoveryInterface
+}
+
+func (f *fakeK8sClientGetter) GetClientset() kubernetes.Interface  { return f.clientset }
+func (f *fakeK8sClientGetter) GetDynamicClient() dynamic.Interface { return f.dynamic }
+func (f *fakeK8sClientGetter) GetDiscoveryClient() discovery.DiscoveryInterface {
+	return f.discovery
+}
 
 // mockCollector implements Collector for testing.
 type mockCollector struct {
@@ -148,10 +169,32 @@ func TestCollectorFactoryFunc(t *testing.T) {
 	})
 }
 
-// Note: DetectFlowCollector tests are more complex as they require:
-// - Fake K8s clientset with specific namespaces/resources
-// - Mocking IsCiliumAvailable (requires Hubble relay connection)
-// - Mocking IsOVNKDeployed (simpler, just checks namespace)
-// Full detection logic tests should inject the detection functions
-// or use integration tests. See collector/cilium_test.go and
-// collector/ovnk_test.go for unit tests of the detection helpers.
+// TestDetectFlowCollector_NoSupportedCNI verifies that when no supported CNI is
+// detected the operator does NOT fall back to any collector: it reports
+// FLOW_COLLECTOR_DISABLED and returns a nil factory so main.go skips registering
+// a flow-collector stream.
+func TestDetectFlowCollector_NoSupportedCNI(t *testing.T) {
+	// Empty clientset: no Hubble Relay service (Cilium unavailable), no OVN-K
+	// namespace, no aws-node pods (AWS VPC CNI unavailable) -> falls through.
+	getter := &fakeK8sClientGetter{
+		clientset: k8sfake.NewClientset(),
+		dynamic:   dynamicfake.NewSimpleDynamicClient(runtimescheme.NewScheme()),
+	}
+
+	flowCollectorType, name, factory := DetectFlowCollector(context.Background(), CollectorConfig{
+		Logger:           zap.NewNop(),
+		K8sClient:        getter,
+		CiliumNamespaces: []string{"kube-system"},
+		OVNKNamespace:    "openshift-ovn-kubernetes",
+	})
+
+	assert.Equal(t, pb.FlowCollector_FLOW_COLLECTOR_DISABLED, flowCollectorType,
+		"no supported CNI should report FLOW_COLLECTOR_DISABLED")
+	assert.Equal(t, "None", name)
+	assert.Nil(t, factory, "no supported CNI should return a nil factory (no fallback)")
+}
+
+// Note: the positive DetectFlowCollector paths (Cilium/OVN-K/AWS VPC CNI) are
+// harder to unit test as they require a fake Hubble Relay connection and
+// resource fixtures. See collector/cilium_test.go and collector/ovnk_test.go
+// for unit tests of the individual detection helpers.


### PR DESCRIPTION
Previously the operator fell back to the Falco flow collector whenever no supported CNI (Cilium+Hubble, OVN-Kubernetes, AWS VPC CNI) was detected. This started a Falco listener that silently received nothing when Falco was not deployed, masking the lack of flow visibility.

DetectFlowCollector now reports FLOW_COLLECTOR_DISABLED and returns a nil factory when no supported CNI is found, logging a warning instead of falling back. main.go only registers the flow-collector stream when a collector is available; the network-flows stream still opens and sends keepalives so the backend sees the cluster with flow collection reported as disabled.